### PR TITLE
TaCZ依存をCurseMavenに切り替え、開発環境の依存問題を根本解決

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,23 +15,41 @@ Minecraft Forge 1.20.1 用のMODプロジェクト。TaCZ（Timeless and Classic
 
 ## 主な依存MOD
 
-- **TaCZ** (Timeless and Classics Zero) - 銃MOD本体 (CurseMaven経由)
+- **TaCZ** (Timeless and Classics Zero) - 銃MOD本体 (ローカルビルド、JarJar付き`-all.jar`)
 - **ApothicAttributes** - 属性拡張ライブラリ
 - **Placebo** - ApothicAttributesの前提ライブラリ
+
+## TaCZ JARの更新手順
+
+TaCZを更新する場合は、**必ずJarJar付きの`-all.jar`を使用**すること。
+
+```bash
+# 1. TaCZソースディレクトリでJarJarタスクを実行
+cd /path/to/TACZ
+./gradlew jarJar
+
+# 2. 生成された-all.jarをlibsにコピー（ファイル名は-allを除く）
+cp build/libs/tacz-1.20.1-X.X.X-all.jar /path/to/TaCZ_Attributes/libs/tacz-1.20.1-X.X.X.jar
+
+# 3. Gradle deobfキャッシュを削除して再生成させる
+rm -rf ~/.gradle/caches/forge_gradle/deobf_dependencies/libs/tacz-1.20.1/
+```
+
+**重要**: 通常の`./gradlew build`で生成されるJARにはJarJar依存（LuaJ, MixinExtras,
+commons-math3, bcel）が含まれない。`-all.jar`を使わないと開発環境で
+`ClassNotFoundException`/`NoClassDefFoundError` が発生する。
 
 ## プロジェクト構造
 
 ```
 src/main/java/com/github/leopoko/tacz_attributes/
 ├── Tacz_attributes.java          # MODメインクラス (@Mod エントリポイント)
-├── Config.java                   # ForgeConfigSpec によるコンフィグ管理
-├── GunDamageModifier.java        # 銃ダメージ倍率の適用 (LivingHurtEvent)
+├── GunDamageModifier.java        # 銃ダメージ倍率の適用 (EntityHurtByGunEvent)
 ├── attribute/
 │   ├── CustomAttributes.java     # カスタム属性の定義・登録
 │   └── EntityAttributeSetup.java # プレイヤーへの属性バインド
 └── mixin/
-    ├── LivingEntityReloadMixin.java    # リロード速度の変更 (Mixin)
-    └── LivingEntityReloadAccessor.java # privateフィールドアクセス用
+    └── LivingEntityReloadMixin.java # リロード速度の変更 (タイムスタンプスケーリング)
 ```
 
 ## カスタム属性

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,28 +15,27 @@ Minecraft Forge 1.20.1 用のMODプロジェクト。TaCZ（Timeless and Classic
 
 ## 主な依存MOD
 
-- **TaCZ** (Timeless and Classics Zero) - 銃MOD本体 (ローカルビルド、JarJar付き`-all.jar`)
+- **TaCZ** (Timeless and Classics Zero) - 銃MOD本体 (CurseMaven経由)
 - **ApothicAttributes** - 属性拡張ライブラリ
 - **Placebo** - ApothicAttributesの前提ライブラリ
 
-## TaCZ JARの更新手順
+## TaCZ依存の管理
 
-TaCZを更新する場合は、**必ずJarJar付きの`-all.jar`を使用**すること。
+TaCZはCurseMavenから取得する。CurseForgeの公開JARにはJarJar依存（LuaJ, MixinExtras,
+commons-math3, bcel）が含まれており、開発環境でもForgeのJarInJarロケーターが
+自動的に展開・ロードする。
 
-```bash
-# 1. TaCZソースディレクトリでJarJarタスクを実行
-cd /path/to/TACZ
-./gradlew jarJar
-
-# 2. 生成された-all.jarをlibsにコピー（ファイル名は-allを除く）
-cp build/libs/tacz-1.20.1-X.X.X-all.jar /path/to/TaCZ_Attributes/libs/tacz-1.20.1-X.X.X.jar
-
-# 3. Gradle deobfキャッシュを削除して再生成させる
-rm -rf ~/.gradle/caches/forge_gradle/deobf_dependencies/libs/tacz-1.20.1/
+```gradle
+// build.gradle の dependencies ブロック
+implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:<fileId>")
 ```
 
-**重要**: 通常の`./gradlew build`で生成されるJARにはJarJar依存（LuaJ, MixinExtras,
-commons-math3, bcel）が含まれない。`-all.jar`を使わないと開発環境で
+**TaCZバージョン更新時**: CurseForgeのファイルIDを更新する。
+ファイルIDは https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero/files
+から確認できる。
+
+**重要**: ローカルビルドのJARを`libs/`に置く方式は使わないこと。
+ローカルJARではJarJar依存がForgeのクラスローダーに正しくロードされず、
 `ClassNotFoundException`/`NoClassDefFoundError` が発生する。
 
 ## プロジェクト構造
@@ -78,3 +77,4 @@ src/main/java/com/github/leopoko/tacz_attributes/
 - `gradle.properties` のテンプレート変数が `mods.toml` と `pack.mcmeta` に展開される
 - 開発環境でのみデバッグログを出力する（`FMLEnvironment.production` で判定）
 - ソースのエンコーディングは UTF-8
+- `build/libs/` にJARが残っていると `runClient` 等でモジュール競合（`ResolutionException`）が発生する。`build.gradle` に自動クリーンフックが設定済み

--- a/build.gradle
+++ b/build.gradle
@@ -152,14 +152,6 @@ repositories {
             includeGroup "dev.shadowsoffire"
         }
     }
-    maven {
-        // LuaJ (TaCZが依存)
-        url = 'https://jitpack.io'
-        content {
-            includeGroup "com.github.FiguraMC.luaj"
-        }
-    }
-
 }
 
 dependencies {
@@ -170,17 +162,13 @@ dependencies {
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    // TaCZ 1.1.7-hotfix (ローカルビルド)
+    // TaCZ 1.1.7-hotfix (ローカルビルド、JarJar依存込みの-all.jar)
+    // JarJar付きJARを使用することで、LuaJ・MixinExtras・commons-math3・bcel等の
+    // 依存ライブラリがForgeのJarJarシステムにより自動展開される
     implementation fg.deobf('libs:tacz-1.20.1:1.1.7-hotfix')
     // ApothicAttributes と前提ライブラリ
     implementation fg.deobf("dev.shadowsoffire:Placebo:1.20.1-8.6.2")
     implementation fg.deobf("dev.shadowsoffire:ApothicAttributes:1.20.1-1.3.7")
-    // TaCZのJarJar依存ライブラリ (開発環境では自動展開されないため明示的に追加)
-    implementation "io.github.llamalad7:mixinextras-forge:0.3.6"
-    implementation "com.github.FiguraMC.luaj:luaj-core:3.0.8-figura"
-    implementation "com.github.FiguraMC.luaj:luaj-jse:3.0.8-figura"
-    implementation "org.apache.commons:commons-math3:3.6.1"
-    implementation "org.apache.bcel:bcel:6.6.1"
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 

--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,6 @@ repositories {
     // Put repositories for dependencies here
     // ForgeGradle automatically adds the Forge maven and Maven Central for you
 
-    flatDir {
-        dir 'libs'
-    }
     maven {
         // Add curse maven to repositories
         name = "Curse Maven"
@@ -162,10 +159,8 @@ dependencies {
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    // TaCZ 1.1.7-hotfix (ローカルビルド、JarJar依存込みの-all.jar)
-    // JarJar付きJARを使用することで、LuaJ・MixinExtras・commons-math3・bcel等の
-    // 依存ライブラリがForgeのJarJarシステムにより自動展開される
-    implementation fg.deobf('libs:tacz-1.20.1:1.1.7-hotfix')
+    // TaCZ (CurseMaven経由)
+    implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:7401617")
     // ApothicAttributes と前提ライブラリ
     implementation fg.deobf("dev.shadowsoffire:Placebo:1.20.1-8.6.2")
     implementation fg.deobf("dev.shadowsoffire:ApothicAttributes:1.20.1-1.3.7")
@@ -209,6 +204,18 @@ tasks.named('jar', Jar).configure {
 
     // This is the preferred method to reobfuscate your jar file
     finalizedBy 'reobfJar'
+}
+
+// build後のJARがrunClient等のモジュールパスに残ると、
+// ソースディレクトリと同一パッケージを持つため
+// java.lang.module.ResolutionException が発生する。
+// Forgeの各種実行タスク前にbuild/libs/を自動クリーンする。
+gradle.taskGraph.whenReady { graph ->
+    graph.allTasks.findAll { it.name.contains('cpw.mods') || it.name.startsWith('run') }.each { task ->
+        task.doFirst {
+            delete fileTree(dir: "${project.buildDir}/libs", include: '*.jar')
+        }
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,13 @@ repositories {
             includeGroup "dev.shadowsoffire"
         }
     }
+    maven {
+        // LuaJ (TaCZが依存)
+        url = 'https://jitpack.io'
+        content {
+            includeGroup "com.github.FiguraMC.luaj"
+        }
+    }
 
 }
 
@@ -168,6 +175,12 @@ dependencies {
     // ApothicAttributes と前提ライブラリ
     implementation fg.deobf("dev.shadowsoffire:Placebo:1.20.1-8.6.2")
     implementation fg.deobf("dev.shadowsoffire:ApothicAttributes:1.20.1-1.3.7")
+    // TaCZのJarJar依存ライブラリ (開発環境では自動展開されないため明示的に追加)
+    implementation "io.github.llamalad7:mixinextras-forge:0.3.6"
+    implementation "com.github.FiguraMC.luaj:luaj-core:3.0.8-figura"
+    implementation "com.github.FiguraMC.luaj:luaj-jse:3.0.8-figura"
+    implementation "org.apache.commons:commons-math3:3.6.1"
+    implementation "org.apache.bcel:bcel:6.6.1"
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 


### PR DESCRIPTION
## 概要
- TaCZ依存をローカルJARからCurseMavenに切り替え
- 開発環境での `ClassNotFoundException` / `NoClassDefFoundError` を根本的に解決
- ビルド時のモジュール競合（`ResolutionException`）を防止するフックを追加

## 変更内容
- **build.gradle**: TaCZ依存を `curse.maven:timeless-and-classics-zero-1028108:7401617` に変更
- **build.gradle**: 不要になった `flatDir` リポジトリを削除
- **build.gradle**: `runClient` 実行前に `build/libs/` を自動クリーンするフックを追加
- **libs/**: ローカルTaCZ JARを削除
- **CLAUDE.md**: TaCZ依存管理の手順をCurseMaven方式に更新

## 背景
TaCZはLuaJ, MixinExtras, commons-math3, bcelをJarJarでMOD JARに内包しています。

ローカルビルドのJARを `fg.deobf()` で使用した場合、以下の問題が発生しました:
1. JarJar依存がForgeのクラスローダーに正しくロードされない
2. `files()` で個別JARを追加しても、mods.tomlを持たないライブラリ（LuaJ等）はForgeのモジュールシステムに認識されない

CurseMavenの公開JARはJarJarメタデータを含んでおり、ForgeのJarInJarロケーターが開発環境でも自動的に展開・ロードするため、これらの問題が根本的に解決されます。

## テスト結果
- [x] `./gradlew build` が成功
- [x] `./gradlew runClient` でゲームが正常起動
- [x] TaCZ (1.1.7-hotfix) が正常にロード
- [x] JarJar依存（LuaJ, MixinExtras, commons-math3, bcel）が全て解決
- [x] モジュール競合が発生しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)