### PR TITLE
リロードアニメーション速度同期、gun_damage修正、銃種別属性の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,22 @@ src/main/java/com/github/leopoko/tacz_attributes/
 ## ビルド
 
 ```bash
-./gradlew build        # JARをビルド (reobfJar が自動実行される)
-./gradlew runClient    # クライアント起動
-./gradlew runServer    # サーバー起動
+./gradlew build           # JARをビルド (reobfJar が自動実行される)
+./gradlew runClient       # クライアント起動 (Gradleから)
+./gradlew runServer       # サーバー起動
+./gradlew genIntellijRuns # IntelliJのrun設定を生成
 ```
+
+## 開発環境セットアップ
+
+クローン後またはブランチ切り替え後、IntelliJの再生ボタンで起動するには:
+
+```bash
+./gradlew genIntellijRuns
+```
+
+を実行する必要がある。これにより `.idea/runConfigurations/` にrun設定が生成される。
+この設定は `.gitignore` に含まれておりコミットされないため、各開発者がローカルで実行する。
 
 ## 開発上の注意
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,19 +44,44 @@ implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:<fileId>
 src/main/java/com/github/leopoko/tacz_attributes/
 ├── Tacz_attributes.java          # MODメインクラス (@Mod エントリポイント)
 ├── GunDamageModifier.java        # 銃ダメージ倍率の適用 (EntityHurtByGunEvent)
+├── api/
+│   └── ISpeedModifiable.java     # アニメーション速度倍率のダックインターフェース
 ├── attribute/
 │   ├── CustomAttributes.java     # カスタム属性の定義・登録
-│   └── EntityAttributeSetup.java # プレイヤーへの属性バインド
-└── mixin/
-    └── LivingEntityReloadMixin.java # リロード速度の変更 (タイムスタンプスケーリング)
+│   ├── EntityAttributeSetup.java # プレイヤーへの属性バインド
+│   └── GunType.java              # 銃種enum・銃種別属性の定義
+├── client/
+│   └── ReloadAnimationSpeedHandler.java # クライアント側リロードアニメーション速度同期
+├── mixin/
+│   ├── LivingEntityReloadMixin.java     # リロード速度の変更 (タイムスタンプスケーリング)
+│   └── ObjectAnimationRunnerMixin.java  # アニメーション速度倍率のMixin
+└── util/
+    └── GunTypeResolver.java      # gunId/ItemStack → GunType 解決ユーティリティ
 ```
 
 ## カスタム属性
 
+### 全銃共通
+
 | 属性 | ID | デフォルト | 範囲 | 説明 |
 |------|-----|-----------|------|------|
-| GUN_DAMAGE | `gun_damage` | 1.0 | 0.0〜1024.0 | 銃弾ダメージの倍率 |
-| RELOAD_SPEED | `reload_speed` | 1.0 | 0.1〜20.0 | リロード速度の倍率 |
+| GUN_DAMAGE | `gun_damage` | 1.0 | 0.0〜1024.0 | 全銃弾ダメージの倍率 |
+| RELOAD_SPEED | `reload_speed` | 1.0 | 0.1〜20.0 | 全銃リロード速度の倍率 |
+
+### 銃種別（最終倍率 = 全体 × 銃種別）
+
+| 銃種 | ダメージ属性 | リロード速度属性 |
+|------|------------|----------------|
+| PISTOL | `pistol_damage` | `pistol_reload_speed` |
+| SNIPER | `sniper_damage` | `sniper_reload_speed` |
+| RIFLE | `rifle_damage` | `rifle_reload_speed` |
+| SHOTGUN | `shotgun_damage` | `shotgun_reload_speed` |
+| SMG | `smg_damage` | `smg_reload_speed` |
+| RPG | `rpg_damage` | `rpg_reload_speed` |
+| MG | `mg_damage` | `mg_reload_speed` |
+
+銃種別属性のデフォルト値はすべて 1.0（変更なし）、範囲はダメージ: 0.0〜1024.0、リロード速度: 0.1〜20.0。
+銃種は TaCZ の `GunTabType` に準拠し、`GunType` enum で管理される。
 
 ## MOD ID
 

--- a/src/main/java/com/github/leopoko/tacz_attributes/GunDamageModifier.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/GunDamageModifier.java
@@ -1,8 +1,12 @@
 package com.github.leopoko.tacz_attributes;
 
 import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
 import com.tacz.guns.api.event.common.EntityHurtByGunEvent;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.common.Mod;
@@ -10,7 +14,7 @@ import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod.EventBusSubscriber
+@Mod.EventBusSubscriber(modid = Tacz_attributes.MODID)
 public class GunDamageModifier {
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -21,16 +25,34 @@ public class GunDamageModifier {
         LivingEntity attacker = event.getAttacker();
         if (attacker == null) return;
 
+        // 全体ダメージ倍率
+        double globalModifier = 1.0;
         if (attacker.getAttributes().hasAttribute(CustomAttributes.GUN_DAMAGE.get())) {
-            double damageModifier = attacker.getAttributeValue(CustomAttributes.GUN_DAMAGE.get());
-            float modifiedDamage = (float) (event.getBaseAmount() * damageModifier);
-
-            if (!FMLEnvironment.production) {
-                LOGGER.debug("銃ダメージ倍率適用: {} -> {} (倍率: {})",
-                        event.getBaseAmount(), modifiedDamage, damageModifier);
-            }
-
-            event.setBaseAmount(modifiedDamage);
+            globalModifier = attacker.getAttributeValue(CustomAttributes.GUN_DAMAGE.get());
         }
+
+        // 銃種別ダメージ倍率
+        double typeModifier = 1.0;
+        ResourceLocation gunId = event.getGunId();
+        GunType gunType = GunTypeResolver.resolve(gunId);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getDamageAttribute().get();
+            if (attacker.getAttributes().hasAttribute(typeAttr)) {
+                typeModifier = attacker.getAttributeValue(typeAttr);
+            }
+        }
+
+        double combinedModifier = globalModifier * typeModifier;
+        if (combinedModifier == 1.0) return;
+
+        float modifiedDamage = (float) (event.getBaseAmount() * combinedModifier);
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] 銃ダメージ倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
+                    event.getBaseAmount(), modifiedDamage, globalModifier,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeModifier);
+        }
+
+        event.setBaseAmount(modifiedDamage);
     }
 }

--- a/src/main/java/com/github/leopoko/tacz_attributes/api/ISpeedModifiable.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/api/ISpeedModifiable.java
@@ -1,0 +1,10 @@
+package com.github.leopoko.tacz_attributes.api;
+
+/**
+ * ObjectAnimationRunner に速度倍率フィールドを追加するためのダックインターフェース。
+ * クライアントMixin経由で実装される。
+ */
+public interface ISpeedModifiable {
+    float tacz_attributes$getSpeedMultiplier();
+    void tacz_attributes$setSpeedMultiplier(float speed);
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
@@ -17,4 +17,9 @@ public class CustomAttributes {
 
     public static final RegistryObject<Attribute> RELOAD_SPEED = ATTRIBUTES.register("reload_speed",
             () -> new RangedAttribute("attribute.tacz_attributes.reload_speed", 1.0, 0.1, 20.0).setSyncable(true));
+
+    // 銃種別属性の一括登録
+    static {
+        GunType.registerAll(ATTRIBUTES);
+    }
 }

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
@@ -13,6 +13,12 @@ public class EntityAttributeSetup {
         if (event.getTypes().contains(EntityType.PLAYER)) {
             event.add(EntityType.PLAYER, CustomAttributes.GUN_DAMAGE.get());
             event.add(EntityType.PLAYER, CustomAttributes.RELOAD_SPEED.get());
+
+            // 銃種別属性
+            for (GunType gunType : GunType.values()) {
+                event.add(EntityType.PLAYER, gunType.getDamageAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getReloadSpeedAttribute().get());
+            }
         }
     }
 }

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
@@ -1,0 +1,84 @@
+package com.github.leopoko.tacz_attributes.attribute;
+
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * TaCZ の銃種分類に対応する enum。
+ * 各銃種ごとにダメージ倍率とリロード速度倍率の属性を保持する。
+ */
+public enum GunType {
+    PISTOL("pistol"),
+    SNIPER("sniper"),
+    RIFLE("rifle"),
+    SHOTGUN("shotgun"),
+    SMG("smg"),
+    RPG("rpg"),
+    MG("mg");
+
+    private final String typeId;
+    private RegistryObject<Attribute> damageAttribute;
+    private RegistryObject<Attribute> reloadSpeedAttribute;
+
+    private static final Map<String, GunType> BY_TYPE_ID = new HashMap<>();
+
+    static {
+        for (GunType type : values()) {
+            BY_TYPE_ID.put(type.typeId, type);
+        }
+    }
+
+    GunType(String typeId) {
+        this.typeId = typeId;
+    }
+
+    public String getTypeId() {
+        return typeId;
+    }
+
+    public RegistryObject<Attribute> getDamageAttribute() {
+        return damageAttribute;
+    }
+
+    public RegistryObject<Attribute> getReloadSpeedAttribute() {
+        return reloadSpeedAttribute;
+    }
+
+    /**
+     * TaCZ の銃種文字列（CommonGunIndex.getType() の戻り値）から GunType を取得する。
+     * 不明な銃種の場合は null を返す。
+     */
+    @Nullable
+    public static GunType fromTypeId(String typeId) {
+        return BY_TYPE_ID.get(typeId);
+    }
+
+    /**
+     * 全銃種の属性を DeferredRegister に一括登録する。
+     * CustomAttributes の static 初期化で呼び出す。
+     */
+    public static void registerAll(DeferredRegister<Attribute> registry) {
+        for (GunType type : values()) {
+            type.damageAttribute = registry.register(
+                    type.typeId + "_damage",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_damage",
+                            1.0, 0.0, 1024.0
+                    ).setSyncable(true)
+            );
+            type.reloadSpeedAttribute = registry.register(
+                    type.typeId + "_reload_speed",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_reload_speed",
+                            1.0, 0.1, 20.0
+                    ).setSyncable(true)
+            );
+        }
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/client/ReloadAnimationSpeedHandler.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/client/ReloadAnimationSpeedHandler.java
@@ -1,0 +1,150 @@
+package com.github.leopoko.tacz_attributes.client;
+
+import com.github.leopoko.tacz_attributes.Tacz_attributes;
+import com.github.leopoko.tacz_attributes.api.ISpeedModifiable;
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.client.animation.AnimationController;
+import com.tacz.guns.api.client.animation.DiscreteTrackArray;
+import com.tacz.guns.api.client.animation.ObjectAnimationRunner;
+import com.tacz.guns.api.client.animation.statemachine.AnimationStateMachine;
+import com.tacz.guns.api.entity.IGunOperator;
+import com.tacz.guns.api.entity.ReloadState;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.client.resource.GunDisplayInstance;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * クライアント側でリロードアニメーションの速度をリロード速度属性に追従させるイベントハンドラ。
+ * <p>
+ * 毎クライアントtickで以下を行う:
+ * 1. プレイヤーのリロード速度属性を取得
+ * 2. リロード中であればMAIN_TRACKのアニメーションランナーに速度倍率を設定
+ * 3. リロード終了時に速度倍率をリセット
+ * <p>
+ * デフォルトステートマシン（およびその派生）では、MAIN_TRACKは
+ * STATIC_TRACK_LINE (trackLine 0) の 5番目のトラック (index 4) に配置される。
+ */
+@Mod.EventBusSubscriber(modid = Tacz_attributes.MODID, value = Dist.CLIENT)
+public class ReloadAnimationSpeedHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * デフォルトステートマシンでのMAIN_TRACKの位置。
+     * STATIC_TRACK_LINE = 0, MAIN_TRACK = trackIndex 4
+     * (BASE=0, BOLT_CAUGHT=1, SAFETY=2, ADS=3, MAIN=4)
+     */
+    private static final int STATIC_TRACK_LINE = 0;
+    private static final int MAIN_TRACK_INDEX = 4;
+
+    private static boolean wasReloading = false;
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.START) return;
+
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return;
+
+        ReloadState reloadState = IGunOperator.fromLivingEntity(player).getSynReloadState();
+        boolean isReloading = reloadState.getStateType().isReloading();
+
+        if (isReloading) {
+            double speed = getReloadSpeedModifier(player);
+            if (speed != 1.0) {
+                applySpeedToMainTrack(player, (float) speed);
+            }
+            wasReloading = true;
+        } else if (wasReloading) {
+            // リロード終了時に速度倍率をリセット
+            applySpeedToMainTrack(player, 1.0f);
+            wasReloading = false;
+        }
+    }
+
+    private static double getReloadSpeedModifier(LocalPlayer player) {
+        // 全体リロード速度倍率
+        double globalSpeed = 1.0;
+        if (player.getAttributes().hasAttribute(CustomAttributes.RELOAD_SPEED.get())) {
+            globalSpeed = player.getAttributeValue(CustomAttributes.RELOAD_SPEED.get());
+        }
+
+        // 銃種別リロード速度倍率
+        double typeSpeed = 1.0;
+        ItemStack mainHand = player.getMainHandItem();
+        GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
+        if (gunType != null) {
+            net.minecraft.world.entity.ai.attributes.Attribute typeAttr = gunType.getReloadSpeedAttribute().get();
+            if (player.getAttributes().hasAttribute(typeAttr)) {
+                typeSpeed = player.getAttributeValue(typeAttr);
+            }
+        }
+
+        return globalSpeed * typeSpeed;
+    }
+
+    /**
+     * MAIN_TRACKのアニメーションランナーに速度倍率を設定する。
+     * ランナーが遷移中の場合、遷移先のランナーにも設定する。
+     */
+    private static void applySpeedToMainTrack(LocalPlayer player, float speed) {
+        ItemStack mainHand = player.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(mainHand);
+        if (iGun == null) return;
+
+        GunDisplayInstance display = TimelessAPI.getGunDisplay(mainHand).orElse(null);
+        if (display == null) return;
+
+        AnimationStateMachine<?> stateMachine = display.getAnimationStateMachine();
+        if (stateMachine == null || !stateMachine.isInitialized()) return;
+
+        AnimationController controller = stateMachine.getAnimationController();
+        if (controller == null) return;
+
+        // DiscreteTrackArray からMAIN_TRACKのコントローラポインタを取得
+        var context = stateMachine.getContext();
+        if (context == null) return;
+
+        DiscreteTrackArray trackArray = context.getTrackArray();
+        if (trackArray.getTrackLineSize() <= STATIC_TRACK_LINE) return;
+
+        List<Integer> staticTracks = trackArray.getByIndex(STATIC_TRACK_LINE);
+        if (staticTracks.size() <= MAIN_TRACK_INDEX) return;
+
+        int mainTrackPointer = staticTracks.get(MAIN_TRACK_INDEX);
+        ObjectAnimationRunner runner = controller.getAnimation(mainTrackPointer);
+        if (runner == null) return;
+
+        // ランナーに速度倍率を設定
+        setSpeedOnRunner(runner, speed);
+
+        // 遷移先のランナーにも設定
+        ObjectAnimationRunner transitionTo = runner.getTransitionTo();
+        if (transitionTo != null) {
+            setSpeedOnRunner(transitionTo, speed);
+        }
+    }
+
+    private static void setSpeedOnRunner(ObjectAnimationRunner runner, float speed) {
+        if (runner instanceof ISpeedModifiable modifiable) {
+            modifiable.tacz_attributes$setSpeedMultiplier(speed);
+            if (!FMLEnvironment.production && speed != 1.0f) {
+                LOGGER.debug("リロードアニメーション速度倍率設定: {}", speed);
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityReloadMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityReloadMixin.java
@@ -1,10 +1,14 @@
 package com.github.leopoko.tacz_attributes.mixin;
 
 import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
 import com.tacz.guns.api.entity.ReloadState;
 import com.tacz.guns.entity.shooter.LivingEntityReload;
 import com.tacz.guns.entity.shooter.ShooterDataHolder;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -79,9 +83,25 @@ public abstract class LivingEntityReloadMixin {
 
     @Unique
     private double tacz_attributes$getReloadSpeedModifier() {
-        if (shooter != null && shooter.getAttributes().hasAttribute(CustomAttributes.RELOAD_SPEED.get())) {
-            return shooter.getAttributeValue(CustomAttributes.RELOAD_SPEED.get());
+        if (shooter == null) return 1.0;
+
+        // 全体リロード速度倍率
+        double globalSpeed = 1.0;
+        if (shooter.getAttributes().hasAttribute(CustomAttributes.RELOAD_SPEED.get())) {
+            globalSpeed = shooter.getAttributeValue(CustomAttributes.RELOAD_SPEED.get());
         }
-        return 1.0;
+
+        // 銃種別リロード速度倍率
+        double typeSpeed = 1.0;
+        ItemStack mainHand = shooter.getMainHandItem();
+        GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getReloadSpeedAttribute().get();
+            if (shooter.getAttributes().hasAttribute(typeAttr)) {
+                typeSpeed = shooter.getAttributeValue(typeAttr);
+            }
+        }
+
+        return globalSpeed * typeSpeed;
     }
 }

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/ObjectAnimationRunnerMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/ObjectAnimationRunnerMixin.java
@@ -1,0 +1,49 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.api.ISpeedModifiable;
+import com.tacz.guns.api.client.animation.ObjectAnimationRunner;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * ObjectAnimationRunner にアニメーション速度倍率を追加するクライアントMixin。
+ * <p>
+ * updateProgress() の alphaProgress パラメータをスケーリングすることで、
+ * アニメーションの再生速度を変更する。
+ * <p>
+ * updateProgress は update() と updateSoundOnly() の両方から呼ばれるため、
+ * アニメーション進行とサウンドタイミングの両方が正しくスケーリングされる。
+ * <p>
+ * update() 内の transitionProgressNs += alphaProgress は updateProgress のパラメータとは
+ * 別の変数なので、遷移タイミングには影響しない（遷移は通常速度で動作する）。
+ */
+@Mixin(ObjectAnimationRunner.class)
+public class ObjectAnimationRunnerMixin implements ISpeedModifiable {
+
+    @Unique
+    private float tacz_attributes$speedMultiplier = 1.0f;
+
+    @Override
+    public float tacz_attributes$getSpeedMultiplier() {
+        return tacz_attributes$speedMultiplier;
+    }
+
+    @Override
+    public void tacz_attributes$setSpeedMultiplier(float speed) {
+        tacz_attributes$speedMultiplier = speed;
+    }
+
+    /**
+     * updateProgress() の alphaProgress パラメータを速度倍率でスケーリングする。
+     * これにより progressNs の増分が倍率分だけ加速/減速される。
+     */
+    @ModifyVariable(method = "updateProgress", at = @At("HEAD"), argsOnly = true, ordinal = 0, remap = false)
+    private long tacz_attributes$scaleAlphaProgress(long alphaProgress) {
+        if (tacz_attributes$speedMultiplier != 1.0f) {
+            return (long) (alphaProgress * tacz_attributes$speedMultiplier);
+        }
+        return alphaProgress;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/util/GunTypeResolver.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/util/GunTypeResolver.java
@@ -1,0 +1,40 @@
+package com.github.leopoko.tacz_attributes.util;
+
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.item.IGun;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+import javax.annotation.Nullable;
+
+/**
+ * gunId や ItemStack から GunType を解決するユーティリティ。
+ */
+public final class GunTypeResolver {
+
+    private GunTypeResolver() {}
+
+    /**
+     * gunId (ResourceLocation) から GunType を解決する。
+     */
+    @Nullable
+    public static GunType resolve(@Nullable ResourceLocation gunId) {
+        if (gunId == null) return null;
+        return TimelessAPI.getCommonGunIndex(gunId)
+                .map(index -> GunType.fromTypeId(index.getType()))
+                .orElse(null);
+    }
+
+    /**
+     * ItemStack から GunType を解決する。
+     */
+    @Nullable
+    public static GunType resolveFromItem(@Nullable ItemStack stack) {
+        if (stack == null || stack.isEmpty()) return null;
+        IGun iGun = IGun.getIGunOrNull(stack);
+        if (iGun == null) return null;
+        ResourceLocation gunId = iGun.getGunId(stack);
+        return resolve(gunId);
+    }
+}

--- a/src/main/resources/assets/tacz_attributes/lang/en_us.json
+++ b/src/main/resources/assets/tacz_attributes/lang/en_us.json
@@ -1,0 +1,18 @@
+{
+  "attribute.tacz_attributes.gun_damage": "Gun Damage",
+  "attribute.tacz_attributes.reload_speed": "Reload Speed",
+  "attribute.tacz_attributes.pistol_damage": "Pistol Damage",
+  "attribute.tacz_attributes.pistol_reload_speed": "Pistol Reload Speed",
+  "attribute.tacz_attributes.sniper_damage": "Sniper Damage",
+  "attribute.tacz_attributes.sniper_reload_speed": "Sniper Reload Speed",
+  "attribute.tacz_attributes.rifle_damage": "Rifle Damage",
+  "attribute.tacz_attributes.rifle_reload_speed": "Rifle Reload Speed",
+  "attribute.tacz_attributes.shotgun_damage": "Shotgun Damage",
+  "attribute.tacz_attributes.shotgun_reload_speed": "Shotgun Reload Speed",
+  "attribute.tacz_attributes.smg_damage": "SMG Damage",
+  "attribute.tacz_attributes.smg_reload_speed": "SMG Reload Speed",
+  "attribute.tacz_attributes.rpg_damage": "RPG Damage",
+  "attribute.tacz_attributes.rpg_reload_speed": "RPG Reload Speed",
+  "attribute.tacz_attributes.mg_damage": "MG Damage",
+  "attribute.tacz_attributes.mg_reload_speed": "MG Reload Speed"
+}

--- a/src/main/resources/assets/tacz_attributes/lang/ja_jp.json
+++ b/src/main/resources/assets/tacz_attributes/lang/ja_jp.json
@@ -1,0 +1,18 @@
+{
+  "attribute.tacz_attributes.gun_damage": "\u9283\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.reload_speed": "\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.pistol_damage": "\u30d4\u30b9\u30c8\u30eb\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.pistol_reload_speed": "\u30d4\u30b9\u30c8\u30eb\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.sniper_damage": "\u30b9\u30ca\u30a4\u30d1\u30fc\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.sniper_reload_speed": "\u30b9\u30ca\u30a4\u30d1\u30fc\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.rifle_damage": "\u30e9\u30a4\u30d5\u30eb\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.rifle_reload_speed": "\u30e9\u30a4\u30d5\u30eb\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.shotgun_damage": "\u30b7\u30e7\u30c3\u30c8\u30ac\u30f3\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.shotgun_reload_speed": "\u30b7\u30e7\u30c3\u30c8\u30ac\u30f3\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.smg_damage": "SMG\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.smg_reload_speed": "SMG\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.rpg_damage": "RPG\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.rpg_reload_speed": "RPG\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6",
+  "attribute.tacz_attributes.mg_damage": "MG\u30c0\u30e1\u30fc\u30b8",
+  "attribute.tacz_attributes.mg_reload_speed": "MG\u30ea\u30ed\u30fc\u30c9\u901f\u5ea6"
+}

--- a/src/main/resources/tacz_attributes.mixins.json
+++ b/src/main/resources/tacz_attributes.mixins.json
@@ -8,6 +8,7 @@
     "LivingEntityReloadMixin"
   ],
   "client": [
+    "ObjectAnimationRunnerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- リロードアニメーションが `reload_speed` 属性に追従するよう `ObjectAnimationRunner` に速度倍率Mixinを追加
- `ISpeedModifiable` を mixin パッケージから api パッケージに移動し `IllegalClassLoadError` を修正
- `GunDamageModifier` に明示的な modid と INFO レベルログを追加
- 銃種別属性（7種×ダメージ/リロード速度＝14属性）を追加
  - `GunType` enum で銃種定義と属性登録を集約
  - `GunTypeResolver` で gunId/ItemStack からの銃種解決を共通化
  - 最終倍率 = 全体属性 × 銃種別属性
  - 対応銃種: PISTOL, SNIPER, RIFLE, SHOTGUN, SMG, RPG, MG
- 日英の言語リソースファイルを追加
- CLAUDE.md のプロジェクト構造と属性一覧を更新

## Test plan
- [ ] `./gradlew build` でビルド成功を確認
- [ ] `./gradlew runClient` でクライアント起動
- [ ] `/attribute @p tacz_attributes:pistol_damage base set 3.0` でピストルのダメージ3倍を確認
- [ ] ピストルでMobを攻撃 → ダメージが3倍。ライフルでは通常ダメージ
- [ ] `/attribute @p tacz_attributes:gun_damage base set 2.0` と組み合わせ → ピストルは6倍、ライフルは2倍
- [ ] `/attribute @p tacz_attributes:shotgun_reload_speed base set 2.0` → ショットガンのみリロード2倍速（アニメーション含む）
- [ ] リロードアニメーションが `reload_speed` 属性に正しく追従することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)