### PR TITLE
コッキング速度・マガジン容量・弾薬関連の属性を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:<fileId>
 src/main/java/com/github/leopoko/tacz_attributes/
 ├── Tacz_attributes.java          # MODメインクラス (@Mod エントリポイント)
 ├── GunDamageModifier.java        # 銃ダメージ倍率の適用 (EntityHurtByGunEvent)
+├── GunKillAmmoRecovery.java     # キル時弾薬回復の適用 (EntityKillByGunEvent)
 ├── api/
 │   └── ISpeedModifiable.java     # アニメーション速度倍率のダックインターフェース
 ├── attribute/
@@ -51,12 +52,17 @@ src/main/java/com/github/leopoko/tacz_attributes/
 │   ├── EntityAttributeSetup.java # プレイヤーへの属性バインド
 │   └── GunType.java              # 銃種enum・銃種別属性の定義
 ├── client/
-│   └── ReloadAnimationSpeedHandler.java # クライアント側リロードアニメーション速度同期
+│   └── ReloadAnimationSpeedHandler.java # クライアント側リロード/ボルトアニメーション速度同期
 ├── mixin/
+│   ├── GunDataMixin.java                # マガジン容量倍率の適用 (ShooterContext連携)
+│   ├── LivingEntityBoltMixin.java       # コッキング速度の変更 (タイムスタンプスケーリング)
 │   ├── LivingEntityReloadMixin.java     # リロード速度の変更 (タイムスタンプスケーリング)
+│   ├── ModernKineticGunScriptAPIMixin.java # 弾薬非消費・リロード時弾薬非消費・追加弾薬の適用
 │   └── ObjectAnimationRunnerMixin.java  # アニメーション速度倍率のMixin
 └── util/
-    └── GunTypeResolver.java      # gunId/ItemStack → GunType 解決ユーティリティ
+    ├── GunTypeResolver.java      # gunId/ItemStack → GunType 解決ユーティリティ
+    ├── ReloadFinishingContext.java # リロード処理中フラグ管理 (ThreadLocal)
+    └── ShooterContext.java       # ThreadLocalによるプレイヤーコンテキスト管理
 ```
 
 ## カスタム属性
@@ -67,20 +73,41 @@ src/main/java/com/github/leopoko/tacz_attributes/
 |------|-----|-----------|------|------|
 | GUN_DAMAGE | `gun_damage` | 1.0 | 0.0〜1024.0 | 全銃弾ダメージの倍率 |
 | RELOAD_SPEED | `reload_speed` | 1.0 | 0.1〜20.0 | 全銃リロード速度の倍率 |
+| BOLT_ACTION_SPEED | `bolt_action_speed` | 1.0 | 0.1〜20.0 | 全銃コッキング速度の倍率 |
+| MAGAZINE_CAPACITY | `magazine_capacity` | 1.0 | 0.1〜100.0 | 全銃マガジン容量の倍率 |
+| AMMO_SAVE_CHANCE | `ammo_save_chance` | 0.0 | 0.0〜1.0 | 射撃時弾薬を消費しない確率 |
+| AMMO_RECOVERY_CHANCE | `ammo_recovery_chance` | 0.0 | 0.0〜1.0 | キル時に弾薬が回復する確率 |
+| AMMO_RECOVERY_AMOUNT | `ammo_recovery_amount` | 0.0 | 0.0〜100.0 | キル時に回復する弾薬の固定数 |
+| AMMO_RECOVERY_PERCENT | `ammo_recovery_percent` | 0.0 | 0.0〜1.0 | キル時に回復する弾薬のマガジン容量比率 |
+| RELOAD_AMMO_SAVE_CHANCE | `reload_ammo_save_chance` | 0.0 | 0.0〜1.0 | リロード時にインベントリ弾薬を消費しない確率 |
+| BONUS_AMMO_CHANCE | `bonus_ammo_chance` | 0.0 | 0.0〜1.0 | リロード完了時に追加弾薬が装填される確率 |
+| BONUS_AMMO_AMOUNT | `bonus_ammo_amount` | 0.0 | 0.0〜100.0 | 追加装填される弾薬の固定数 |
+| BONUS_AMMO_PERCENT | `bonus_ammo_percent` | 0.0 | 0.0〜1.0 | 追加装填される弾薬のマガジン容量比率 |
 
-### 銃種別（最終倍率 = 全体 × 銃種別）
+### 銃種別
 
-| 銃種 | ダメージ属性 | リロード速度属性 |
-|------|------------|----------------|
-| PISTOL | `pistol_damage` | `pistol_reload_speed` |
-| SNIPER | `sniper_damage` | `sniper_reload_speed` |
-| RIFLE | `rifle_damage` | `rifle_reload_speed` |
-| SHOTGUN | `shotgun_damage` | `shotgun_reload_speed` |
-| SMG | `smg_damage` | `smg_reload_speed` |
-| RPG | `rpg_damage` | `rpg_reload_speed` |
-| MG | `mg_damage` | `mg_reload_speed` |
+ダメージ・リロード速度・コッキング速度・マガジン容量は乗算合成（最終倍率 = 全体 × 銃種別）。
+確率・数量系は加算合成（最終値 = min(上限, 全体 + 銃種別)）。
 
-銃種別属性のデフォルト値はすべて 1.0（変更なし）、範囲はダメージ: 0.0〜1024.0、リロード速度: 0.1〜20.0。
+各銃種（PISTOL, SNIPER, RIFLE, SHOTGUN, SMG, RPG, MG）ごとに以下の属性が存在する:
+
+| カテゴリ | 属性サフィックス | 命名例（PISTOL） |
+|---------|----------------|-----------------|
+| ダメージ | `_damage` | `pistol_damage` |
+| リロード速度 | `_reload_speed` | `pistol_reload_speed` |
+| コッキング速度 | `_bolt_action_speed` | `pistol_bolt_action_speed` |
+| マガジン容量 | `_magazine_capacity` | `pistol_magazine_capacity` |
+| 射撃時弾薬非消費確率 | `_ammo_save_chance` | `pistol_ammo_save_chance` |
+| キル時弾薬回復確率 | `_ammo_recovery_chance` | `pistol_ammo_recovery_chance` |
+| キル時弾薬回復量（固定） | `_ammo_recovery_amount` | `pistol_ammo_recovery_amount` |
+| キル時弾薬回復量（割合） | `_ammo_recovery_percent` | `pistol_ammo_recovery_percent` |
+| リロード時弾薬非消費確率 | `_reload_ammo_save_chance` | `pistol_reload_ammo_save_chance` |
+| リロード時追加弾薬確率 | `_bonus_ammo_chance` | `pistol_bonus_ammo_chance` |
+| リロード時追加弾薬量（固定） | `_bonus_ammo_amount` | `pistol_bonus_ammo_amount` |
+| リロード時追加弾薬量（割合） | `_bonus_ammo_percent` | `pistol_bonus_ammo_percent` |
+
+銃種別属性のデフォルト値は倍率系がすべて 1.0（変更なし）、確率・数量系が 0.0（発動なし）。
+範囲はダメージ: 0.0〜1024.0、速度系: 0.1〜20.0、マガジン容量: 0.1〜100.0、確率: 0.0〜1.0、数量: 0.0〜100.0。
 銃種は TaCZ の `GunTabType` に準拠し、`GunType` enum で管理される。
 
 ## MOD ID

--- a/src/main/java/com/github/leopoko/tacz_attributes/GunKillAmmoRecovery.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/GunKillAmmoRecovery.java
@@ -1,0 +1,115 @@
+package com.github.leopoko.tacz_attributes;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.event.common.EntityKillByGunEvent;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.util.AttachmentDataUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * キル時弾薬回復イベントハンドラ。
+ * <p>
+ * EntityKillByGunEvent を受け取り、攻撃者の属性に基づいて弾薬を回復する。
+ * 回復量 = 固定数 + ceil(マガジン最大容量 × 割合)
+ * マガジン最大容量を超えた回復も許可される。
+ */
+@Mod.EventBusSubscriber(modid = Tacz_attributes.MODID)
+public class GunKillAmmoRecovery {
+
+    @SubscribeEvent
+    public static void onGunKill(EntityKillByGunEvent event) {
+        if (event.getLogicalSide() != LogicalSide.SERVER) return;
+
+        LivingEntity attacker = event.getAttacker();
+        if (attacker == null) return;
+
+        ResourceLocation gunId = event.getGunId();
+        GunType gunType = GunTypeResolver.resolve(gunId);
+
+        // 確率判定
+        double chance = getAmmoRecoveryChance(attacker, gunType);
+        if (chance <= 0) return;
+        if (attacker.getRandom().nextDouble() >= chance) return;
+
+        // 攻撃者のメインハンドから銃を取得
+        ItemStack mainHand = attacker.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(mainHand);
+        if (iGun == null) return;
+
+        // 回復量を計算
+        int recoveryAmount = calculateRecoveryAmount(attacker, mainHand, gunType);
+        if (recoveryAmount <= 0) return;
+
+        // 弾薬を回復（マガジン上限を超えてもよい）
+        int currentAmmo = iGun.getCurrentAmmoCount(mainHand);
+        iGun.setCurrentAmmoCount(mainHand, currentAmmo + recoveryAmount);
+    }
+
+    private static double getAmmoRecoveryChance(LivingEntity attacker, GunType gunType) {
+        double globalChance = 0.0;
+        if (attacker.getAttributes().hasAttribute(CustomAttributes.AMMO_RECOVERY_CHANCE.get())) {
+            globalChance = attacker.getAttributeValue(CustomAttributes.AMMO_RECOVERY_CHANCE.get());
+        }
+
+        double typeChance = 0.0;
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getAmmoRecoveryChanceAttribute().get();
+            if (attacker.getAttributes().hasAttribute(typeAttr)) {
+                typeChance = attacker.getAttributeValue(typeAttr);
+            }
+        }
+
+        return Math.min(1.0, globalChance + typeChance);
+    }
+
+    private static int calculateRecoveryAmount(LivingEntity attacker, ItemStack mainHand, GunType gunType) {
+        // 固定数（全体 + 銃種別）
+        double fixedAmount = getAttributeSum(attacker,
+                CustomAttributes.AMMO_RECOVERY_AMOUNT.get(),
+                gunType != null ? gunType.getAmmoRecoveryAmountAttribute().get() : null);
+
+        // 割合（全体 + 銃種別）
+        double percent = Math.min(1.0, getAttributeSum(attacker,
+                CustomAttributes.AMMO_RECOVERY_PERCENT.get(),
+                gunType != null ? gunType.getAmmoRecoveryPercentAttribute().get() : null));
+
+        // マガジン最大容量を取得
+        int maxAmmo = getMaxAmmo(mainHand);
+
+        return (int) Math.round(fixedAmount) + (int) Math.ceil(maxAmmo * percent);
+    }
+
+    private static double getAttributeSum(LivingEntity entity,
+                                          Attribute globalAttr, Attribute typeAttr) {
+        double global = 0.0;
+        if (entity.getAttributes().hasAttribute(globalAttr)) {
+            global = entity.getAttributeValue(globalAttr);
+        }
+
+        double type = 0.0;
+        if (typeAttr != null && entity.getAttributes().hasAttribute(typeAttr)) {
+            type = entity.getAttributeValue(typeAttr);
+        }
+
+        return global + type;
+    }
+
+    private static int getMaxAmmo(ItemStack gunStack) {
+        IGun iGun = IGun.getIGunOrNull(gunStack);
+        if (iGun == null) return 0;
+
+        ResourceLocation gunId = iGun.getGunId(gunStack);
+        return TimelessAPI.getCommonGunIndex(gunId)
+                .map(index -> AttachmentDataUtils.getAmmoCountWithAttachment(gunStack, index.getGunData()))
+                .orElse(0);
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
@@ -11,12 +11,61 @@ import net.minecraftforge.registries.RegistryObject;
 public class CustomAttributes {
     public static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(ForgeRegistries.ATTRIBUTES, Tacz_attributes.MODID);
 
-    // カスタム属性 gun_damage の定義
+    // === 全銃共通属性 ===
+
+    // 全銃弾ダメージの倍率
     public static final RegistryObject<Attribute> GUN_DAMAGE = ATTRIBUTES.register("gun_damage",
             () -> new RangedAttribute("attribute.tacz_attributes.gun_damage", 1.0, 0.0, 1024.0).setSyncable(true));
 
+    // 全銃リロード速度の倍率
     public static final RegistryObject<Attribute> RELOAD_SPEED = ATTRIBUTES.register("reload_speed",
             () -> new RangedAttribute("attribute.tacz_attributes.reload_speed", 1.0, 0.1, 20.0).setSyncable(true));
+
+    // 全銃コッキング（ボルトアクション）速度の倍率
+    public static final RegistryObject<Attribute> BOLT_ACTION_SPEED = ATTRIBUTES.register("bolt_action_speed",
+            () -> new RangedAttribute("attribute.tacz_attributes.bolt_action_speed", 1.0, 0.1, 20.0).setSyncable(true));
+
+    // 全銃マガジン容量の倍率
+    public static final RegistryObject<Attribute> MAGAZINE_CAPACITY = ATTRIBUTES.register("magazine_capacity",
+            () -> new RangedAttribute("attribute.tacz_attributes.magazine_capacity", 1.0, 0.1, 100.0).setSyncable(true));
+
+    // 全銃の弾薬を消費しない確率 (0.0 = 0%, 1.0 = 100%)
+    public static final RegistryObject<Attribute> AMMO_SAVE_CHANCE = ATTRIBUTES.register("ammo_save_chance",
+            () -> new RangedAttribute("attribute.tacz_attributes.ammo_save_chance", 0.0, 0.0, 1.0).setSyncable(true));
+
+    // === キル時弾薬回復 ===
+
+    // キル時に弾薬が回復する確率
+    public static final RegistryObject<Attribute> AMMO_RECOVERY_CHANCE = ATTRIBUTES.register("ammo_recovery_chance",
+            () -> new RangedAttribute("attribute.tacz_attributes.ammo_recovery_chance", 0.0, 0.0, 1.0).setSyncable(true));
+
+    // キル時に回復する弾薬の固定数
+    public static final RegistryObject<Attribute> AMMO_RECOVERY_AMOUNT = ATTRIBUTES.register("ammo_recovery_amount",
+            () -> new RangedAttribute("attribute.tacz_attributes.ammo_recovery_amount", 0.0, 0.0, 100.0).setSyncable(true));
+
+    // キル時に回復する弾薬のマガジン容量比率
+    public static final RegistryObject<Attribute> AMMO_RECOVERY_PERCENT = ATTRIBUTES.register("ammo_recovery_percent",
+            () -> new RangedAttribute("attribute.tacz_attributes.ammo_recovery_percent", 0.0, 0.0, 1.0).setSyncable(true));
+
+    // === リロード時弾薬非消費 ===
+
+    // リロード時にインベントリ弾薬を消費しない確率
+    public static final RegistryObject<Attribute> RELOAD_AMMO_SAVE_CHANCE = ATTRIBUTES.register("reload_ammo_save_chance",
+            () -> new RangedAttribute("attribute.tacz_attributes.reload_ammo_save_chance", 0.0, 0.0, 1.0).setSyncable(true));
+
+    // === リロード時追加弾薬 ===
+
+    // リロード完了時に追加弾薬が装填される確率
+    public static final RegistryObject<Attribute> BONUS_AMMO_CHANCE = ATTRIBUTES.register("bonus_ammo_chance",
+            () -> new RangedAttribute("attribute.tacz_attributes.bonus_ammo_chance", 0.0, 0.0, 1.0).setSyncable(true));
+
+    // 追加装填される弾薬の固定数
+    public static final RegistryObject<Attribute> BONUS_AMMO_AMOUNT = ATTRIBUTES.register("bonus_ammo_amount",
+            () -> new RangedAttribute("attribute.tacz_attributes.bonus_ammo_amount", 0.0, 0.0, 100.0).setSyncable(true));
+
+    // 追加装填される弾薬のマガジン容量比率
+    public static final RegistryObject<Attribute> BONUS_AMMO_PERCENT = ATTRIBUTES.register("bonus_ammo_percent",
+            () -> new RangedAttribute("attribute.tacz_attributes.bonus_ammo_percent", 0.0, 0.0, 1.0).setSyncable(true));
 
     // 銃種別属性の一括登録
     static {

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
@@ -11,13 +11,34 @@ public class EntityAttributeSetup {
     @SubscribeEvent
     public static void onEntityAttributeCreation(EntityAttributeModificationEvent event) {
         if (event.getTypes().contains(EntityType.PLAYER)) {
+            // 全銃共通属性
             event.add(EntityType.PLAYER, CustomAttributes.GUN_DAMAGE.get());
             event.add(EntityType.PLAYER, CustomAttributes.RELOAD_SPEED.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BOLT_ACTION_SPEED.get());
+            event.add(EntityType.PLAYER, CustomAttributes.MAGAZINE_CAPACITY.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AMMO_SAVE_CHANCE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AMMO_RECOVERY_CHANCE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AMMO_RECOVERY_AMOUNT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AMMO_RECOVERY_PERCENT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.RELOAD_AMMO_SAVE_CHANCE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BONUS_AMMO_CHANCE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BONUS_AMMO_AMOUNT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BONUS_AMMO_PERCENT.get());
 
             // 銃種別属性
             for (GunType gunType : GunType.values()) {
                 event.add(EntityType.PLAYER, gunType.getDamageAttribute().get());
                 event.add(EntityType.PLAYER, gunType.getReloadSpeedAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBoltActionSpeedAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getMagazineCapacityAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAmmoSaveChanceAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAmmoRecoveryChanceAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAmmoRecoveryAmountAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAmmoRecoveryPercentAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getReloadAmmoSaveChanceAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBonusAmmoChanceAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBonusAmmoAmountAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBonusAmmoPercentAttribute().get());
             }
         }
     }

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
@@ -11,7 +11,9 @@ import java.util.Map;
 
 /**
  * TaCZ の銃種分類に対応する enum。
- * 各銃種ごとにダメージ倍率とリロード速度倍率の属性を保持する。
+ * 各銃種ごとにダメージ倍率、リロード速度倍率、コッキング速度倍率、
+ * マガジン容量倍率、弾薬非消費確率、キル時弾薬回復、リロード時弾薬非消費、
+ * リロード時追加弾薬の属性を保持する。
  */
 public enum GunType {
     PISTOL("pistol"),
@@ -25,6 +27,16 @@ public enum GunType {
     private final String typeId;
     private RegistryObject<Attribute> damageAttribute;
     private RegistryObject<Attribute> reloadSpeedAttribute;
+    private RegistryObject<Attribute> boltActionSpeedAttribute;
+    private RegistryObject<Attribute> magazineCapacityAttribute;
+    private RegistryObject<Attribute> ammoSaveChanceAttribute;
+    private RegistryObject<Attribute> ammoRecoveryChanceAttribute;
+    private RegistryObject<Attribute> ammoRecoveryAmountAttribute;
+    private RegistryObject<Attribute> ammoRecoveryPercentAttribute;
+    private RegistryObject<Attribute> reloadAmmoSaveChanceAttribute;
+    private RegistryObject<Attribute> bonusAmmoChanceAttribute;
+    private RegistryObject<Attribute> bonusAmmoAmountAttribute;
+    private RegistryObject<Attribute> bonusAmmoPercentAttribute;
 
     private static final Map<String, GunType> BY_TYPE_ID = new HashMap<>();
 
@@ -48,6 +60,46 @@ public enum GunType {
 
     public RegistryObject<Attribute> getReloadSpeedAttribute() {
         return reloadSpeedAttribute;
+    }
+
+    public RegistryObject<Attribute> getBoltActionSpeedAttribute() {
+        return boltActionSpeedAttribute;
+    }
+
+    public RegistryObject<Attribute> getMagazineCapacityAttribute() {
+        return magazineCapacityAttribute;
+    }
+
+    public RegistryObject<Attribute> getAmmoSaveChanceAttribute() {
+        return ammoSaveChanceAttribute;
+    }
+
+    public RegistryObject<Attribute> getAmmoRecoveryChanceAttribute() {
+        return ammoRecoveryChanceAttribute;
+    }
+
+    public RegistryObject<Attribute> getAmmoRecoveryAmountAttribute() {
+        return ammoRecoveryAmountAttribute;
+    }
+
+    public RegistryObject<Attribute> getAmmoRecoveryPercentAttribute() {
+        return ammoRecoveryPercentAttribute;
+    }
+
+    public RegistryObject<Attribute> getReloadAmmoSaveChanceAttribute() {
+        return reloadAmmoSaveChanceAttribute;
+    }
+
+    public RegistryObject<Attribute> getBonusAmmoChanceAttribute() {
+        return bonusAmmoChanceAttribute;
+    }
+
+    public RegistryObject<Attribute> getBonusAmmoAmountAttribute() {
+        return bonusAmmoAmountAttribute;
+    }
+
+    public RegistryObject<Attribute> getBonusAmmoPercentAttribute() {
+        return bonusAmmoPercentAttribute;
     }
 
     /**
@@ -77,6 +129,76 @@ public enum GunType {
                     () -> new RangedAttribute(
                             "attribute.tacz_attributes." + type.typeId + "_reload_speed",
                             1.0, 0.1, 20.0
+                    ).setSyncable(true)
+            );
+            type.boltActionSpeedAttribute = registry.register(
+                    type.typeId + "_bolt_action_speed",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_bolt_action_speed",
+                            1.0, 0.1, 20.0
+                    ).setSyncable(true)
+            );
+            type.magazineCapacityAttribute = registry.register(
+                    type.typeId + "_magazine_capacity",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_magazine_capacity",
+                            1.0, 0.1, 100.0
+                    ).setSyncable(true)
+            );
+            type.ammoSaveChanceAttribute = registry.register(
+                    type.typeId + "_ammo_save_chance",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_ammo_save_chance",
+                            0.0, 0.0, 1.0
+                    ).setSyncable(true)
+            );
+            type.ammoRecoveryChanceAttribute = registry.register(
+                    type.typeId + "_ammo_recovery_chance",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_ammo_recovery_chance",
+                            0.0, 0.0, 1.0
+                    ).setSyncable(true)
+            );
+            type.ammoRecoveryAmountAttribute = registry.register(
+                    type.typeId + "_ammo_recovery_amount",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_ammo_recovery_amount",
+                            0.0, 0.0, 100.0
+                    ).setSyncable(true)
+            );
+            type.ammoRecoveryPercentAttribute = registry.register(
+                    type.typeId + "_ammo_recovery_percent",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_ammo_recovery_percent",
+                            0.0, 0.0, 1.0
+                    ).setSyncable(true)
+            );
+            type.reloadAmmoSaveChanceAttribute = registry.register(
+                    type.typeId + "_reload_ammo_save_chance",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_reload_ammo_save_chance",
+                            0.0, 0.0, 1.0
+                    ).setSyncable(true)
+            );
+            type.bonusAmmoChanceAttribute = registry.register(
+                    type.typeId + "_bonus_ammo_chance",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_bonus_ammo_chance",
+                            0.0, 0.0, 1.0
+                    ).setSyncable(true)
+            );
+            type.bonusAmmoAmountAttribute = registry.register(
+                    type.typeId + "_bonus_ammo_amount",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_bonus_ammo_amount",
+                            0.0, 0.0, 100.0
+                    ).setSyncable(true)
+            );
+            type.bonusAmmoPercentAttribute = registry.register(
+                    type.typeId + "_bonus_ammo_percent",
+                    () -> new RangedAttribute(
+                            "attribute.tacz_attributes." + type.typeId + "_bonus_ammo_percent",
+                            0.0, 0.0, 1.0
                     ).setSyncable(true)
             );
         }

--- a/src/main/java/com/github/leopoko/tacz_attributes/client/ReloadAnimationSpeedHandler.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/client/ReloadAnimationSpeedHandler.java
@@ -16,6 +16,7 @@ import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.client.resource.GunDisplayInstance;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.TickEvent;
@@ -28,15 +29,13 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 
 /**
- * クライアント側でリロードアニメーションの速度をリロード速度属性に追従させるイベントハンドラ。
+ * クライアント側でリロード/ボルトアニメーションの速度を属性に追従させるイベントハンドラ。
  * <p>
  * 毎クライアントtickで以下を行う:
- * 1. プレイヤーのリロード速度属性を取得
- * 2. リロード中であればMAIN_TRACKのアニメーションランナーに速度倍率を設定
- * 3. リロード終了時に速度倍率をリセット
- * <p>
- * デフォルトステートマシン（およびその派生）では、MAIN_TRACKは
- * STATIC_TRACK_LINE (trackLine 0) の 5番目のトラック (index 4) に配置される。
+ * 1. プレイヤーのリロード/ボルト状態を確認
+ * 2. リロード中であればリロード速度倍率、ボルト中であればコッキング速度倍率を
+ *    MAIN_TRACKのアニメーションランナーに設定
+ * 3. どちらも終了した時に速度倍率をリセット
  */
 @Mod.EventBusSubscriber(modid = Tacz_attributes.MODID, value = Dist.CLIENT)
 public class ReloadAnimationSpeedHandler {
@@ -51,7 +50,8 @@ public class ReloadAnimationSpeedHandler {
     private static final int STATIC_TRACK_LINE = 0;
     private static final int MAIN_TRACK_INDEX = 4;
 
-    private static boolean wasReloading = false;
+    /** アニメーション速度が変更中であることを示すフラグ */
+    private static boolean wasSpeedModified = false;
 
     @SubscribeEvent
     public static void onClientTick(TickEvent.ClientTickEvent event) {
@@ -60,19 +60,27 @@ public class ReloadAnimationSpeedHandler {
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) return;
 
-        ReloadState reloadState = IGunOperator.fromLivingEntity(player).getSynReloadState();
+        IGunOperator gunOperator = IGunOperator.fromLivingEntity(player);
+        ReloadState reloadState = gunOperator.getSynReloadState();
         boolean isReloading = reloadState.getStateType().isReloading();
+        boolean isBolting = gunOperator.getSynIsBolting();
 
         if (isReloading) {
             double speed = getReloadSpeedModifier(player);
             if (speed != 1.0) {
                 applySpeedToMainTrack(player, (float) speed);
             }
-            wasReloading = true;
-        } else if (wasReloading) {
-            // リロード終了時に速度倍率をリセット
+            wasSpeedModified = true;
+        } else if (isBolting) {
+            double speed = getBoltSpeedModifier(player);
+            if (speed != 1.0) {
+                applySpeedToMainTrack(player, (float) speed);
+            }
+            wasSpeedModified = true;
+        } else if (wasSpeedModified) {
+            // リロード/ボルト終了時に速度倍率をリセット
             applySpeedToMainTrack(player, 1.0f);
-            wasReloading = false;
+            wasSpeedModified = false;
         }
     }
 
@@ -88,7 +96,28 @@ public class ReloadAnimationSpeedHandler {
         ItemStack mainHand = player.getMainHandItem();
         GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
         if (gunType != null) {
-            net.minecraft.world.entity.ai.attributes.Attribute typeAttr = gunType.getReloadSpeedAttribute().get();
+            Attribute typeAttr = gunType.getReloadSpeedAttribute().get();
+            if (player.getAttributes().hasAttribute(typeAttr)) {
+                typeSpeed = player.getAttributeValue(typeAttr);
+            }
+        }
+
+        return globalSpeed * typeSpeed;
+    }
+
+    private static double getBoltSpeedModifier(LocalPlayer player) {
+        // 全体コッキング速度倍率
+        double globalSpeed = 1.0;
+        if (player.getAttributes().hasAttribute(CustomAttributes.BOLT_ACTION_SPEED.get())) {
+            globalSpeed = player.getAttributeValue(CustomAttributes.BOLT_ACTION_SPEED.get());
+        }
+
+        // 銃種別コッキング速度倍率
+        double typeSpeed = 1.0;
+        ItemStack mainHand = player.getMainHandItem();
+        GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getBoltActionSpeedAttribute().get();
             if (player.getAttributes().hasAttribute(typeAttr)) {
                 typeSpeed = player.getAttributeValue(typeAttr);
             }
@@ -143,7 +172,7 @@ public class ReloadAnimationSpeedHandler {
         if (runner instanceof ISpeedModifiable modifiable) {
             modifiable.tacz_attributes$setSpeedMultiplier(speed);
             if (!FMLEnvironment.production && speed != 1.0f) {
-                LOGGER.debug("リロードアニメーション速度倍率設定: {}", speed);
+                LOGGER.debug("アニメーション速度倍率設定: {}", speed);
             }
         }
     }

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/GunDataMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/GunDataMixin.java
@@ -1,0 +1,77 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.ShooterContext;
+import com.tacz.guns.resource.pojo.data.gun.GunData;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * GunData のマガジン容量を属性倍率で変更するMixin。
+ * <p>
+ * ShooterContext の ThreadLocal からプレイヤーと銃種を取得し、
+ * マガジン容量属性の倍率を getAmmoAmount() / getExtendedMagAmmoAmount() の戻り値に適用する。
+ * ShooterContext が設定されていない場合（データ読み込み時など）はオリジナル値をそのまま返す。
+ */
+@Mixin(GunData.class)
+public class GunDataMixin {
+
+    @Inject(method = "getAmmoAmount", at = @At("RETURN"), cancellable = true, remap = false)
+    private void tacz_attributes$modifyAmmoAmount(CallbackInfoReturnable<Integer> cir) {
+        double modifier = tacz_attributes$getMagazineCapacityModifier();
+        if (modifier != 1.0) {
+            cir.setReturnValue(Math.max(1, (int) Math.round(cir.getReturnValue() * modifier)));
+        }
+    }
+
+    @Inject(method = "getExtendedMagAmmoAmount", at = @At("RETURN"), cancellable = true, remap = false)
+    private void tacz_attributes$modifyExtendedMagAmmoAmount(CallbackInfoReturnable<int[]> cir) {
+        int[] original = cir.getReturnValue();
+        if (original == null) return;
+
+        double modifier = tacz_attributes$getMagazineCapacityModifier();
+        if (modifier != 1.0) {
+            int[] modified = new int[original.length];
+            for (int i = 0; i < original.length; i++) {
+                modified[i] = Math.max(1, (int) Math.round(original[i] * modifier));
+            }
+            cir.setReturnValue(modified);
+        }
+    }
+
+    /**
+     * ShooterContext からマガジン容量倍率を計算する。
+     * コンテキストがない場合は 1.0（変更なし）を返す。
+     */
+    @Unique
+    private static double tacz_attributes$getMagazineCapacityModifier() {
+        ShooterContext.ContextData ctx = ShooterContext.get();
+        if (ctx == null) return 1.0;
+
+        LivingEntity shooter = ctx.shooter();
+
+        // 全体マガジン容量倍率
+        double globalModifier = 1.0;
+        if (shooter.getAttributes().hasAttribute(CustomAttributes.MAGAZINE_CAPACITY.get())) {
+            globalModifier = shooter.getAttributeValue(CustomAttributes.MAGAZINE_CAPACITY.get());
+        }
+
+        // 銃種別マガジン容量倍率
+        double typeModifier = 1.0;
+        GunType gunType = ctx.gunType();
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getMagazineCapacityAttribute().get();
+            if (shooter.getAttributes().hasAttribute(typeAttr)) {
+                typeModifier = shooter.getAttributeValue(typeAttr);
+            }
+        }
+
+        return globalModifier * typeModifier;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityBoltMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityBoltMixin.java
@@ -1,0 +1,107 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.github.leopoko.tacz_attributes.util.ShooterContext;
+import com.tacz.guns.entity.shooter.LivingEntityBolt;
+import com.tacz.guns.entity.shooter.ShooterDataHolder;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * コッキング（ボルトアクション）速度属性を適用するMixin。
+ * <p>
+ * リロード速度と同じタイムスタンプスケーリング方式を使用:
+ * tickBolt() の実行前に boltTimestamp を一時的にスケーリングし、
+ * 経過時間がボルト速度倍率分だけ加速/減速して見えるようにする。
+ * 実行後にタイムスタンプを元に戻すことで、次のtickでも正しく計算される。
+ */
+@Mixin(LivingEntityBolt.class)
+public abstract class LivingEntityBoltMixin {
+
+    @Shadow(remap = false)
+    private LivingEntity shooter;
+
+    @Shadow(remap = false)
+    private ShooterDataHolder data;
+
+    /**
+     * スケーリング前のオリジナルの boltTimestamp を保持。
+     * -1 はスケーリングが行われていないことを示す。
+     */
+    @Unique
+    private long tacz_attributes$originalBoltTimestamp = -1;
+
+    /**
+     * tickBolt() の実行前に、ボルトタイムスタンプをスケーリングする。
+     * また、マガジン容量のために ShooterContext を設定する。
+     */
+    @Inject(method = "tickBolt", at = @At("HEAD"), remap = false)
+    private void tacz_attributes$scaleBoltTimestamp(CallbackInfo ci) {
+        tacz_attributes$originalBoltTimestamp = -1;
+
+        if (shooter != null) {
+            ShooterContext.set(shooter);
+        }
+
+        if (!data.isBolting) return;
+
+        double boltSpeedModifier = tacz_attributes$getBoltSpeedModifier();
+        if (boltSpeedModifier == 1.0) return;
+
+        tacz_attributes$originalBoltTimestamp = data.boltTimestamp;
+
+        long now = System.currentTimeMillis();
+        long originalElapsed = now - data.boltTimestamp;
+        long scaledElapsed = (long) (originalElapsed * boltSpeedModifier);
+        data.boltTimestamp = now - scaledElapsed;
+    }
+
+    /**
+     * tickBolt() の実行後に、オリジナルのタイムスタンプを復元する。
+     * また、ShooterContext をクリアする。
+     */
+    @Inject(method = "tickBolt", at = @At("RETURN"), remap = false)
+    private void tacz_attributes$restoreBoltTimestamp(CallbackInfo ci) {
+        ShooterContext.clear();
+
+        if (tacz_attributes$originalBoltTimestamp == -1) return;
+
+        // ボルトが完了した場合（isBolting が false）でもタイムスタンプを復元する。
+        // isBolting が false になった後は boltTimestamp は使用されないため、復元しても問題ない。
+        data.boltTimestamp = tacz_attributes$originalBoltTimestamp;
+        tacz_attributes$originalBoltTimestamp = -1;
+    }
+
+    @Unique
+    private double tacz_attributes$getBoltSpeedModifier() {
+        if (shooter == null) return 1.0;
+
+        // 全体コッキング速度倍率
+        double globalSpeed = 1.0;
+        if (shooter.getAttributes().hasAttribute(CustomAttributes.BOLT_ACTION_SPEED.get())) {
+            globalSpeed = shooter.getAttributeValue(CustomAttributes.BOLT_ACTION_SPEED.get());
+        }
+
+        // 銃種別コッキング速度倍率
+        double typeSpeed = 1.0;
+        ItemStack mainHand = shooter.getMainHandItem();
+        GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getBoltActionSpeedAttribute().get();
+            if (shooter.getAttributes().hasAttribute(typeAttr)) {
+                typeSpeed = shooter.getAttributeValue(typeAttr);
+            }
+        }
+
+        return globalSpeed * typeSpeed;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityReloadMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityReloadMixin.java
@@ -3,6 +3,8 @@ package com.github.leopoko.tacz_attributes.mixin;
 import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
 import com.github.leopoko.tacz_attributes.attribute.GunType;
 import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.github.leopoko.tacz_attributes.util.ReloadFinishingContext;
+import com.github.leopoko.tacz_attributes.util.ShooterContext;
 import com.tacz.guns.api.entity.ReloadState;
 import com.tacz.guns.entity.shooter.LivingEntityReload;
 import com.tacz.guns.entity.shooter.ShooterDataHolder;
@@ -14,6 +16,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
@@ -24,10 +27,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * 経過時間がリロード速度倍率分だけ加速/減速して見えるようにする。
  * 実行後にタイムスタンプを元に戻すことで、次のtickでも正しく計算される。
  * <p>
- * この方式の利点:
- * - TaCZの内部リロードロジック（defaultTickReload、Luaスクリプト）をそのまま利用
- * - ReloadStateのcountdownが正しくスケーリングされ、ModSyncedEntityData経由でクライアントに同期
- * - クライアント側のアニメーションもサーバーからの同期データに基づいて動作するため、同期が取れる
+ * また、マガジン容量属性のために ShooterContext を設定する。
+ * reload() と tickReloadState() の両方で設定し、GunData.getAmmoAmount() が
+ * 呼ばれる際にプレイヤー固有の倍率が適用されるようにする。
  */
 @Mixin(LivingEntityReload.class)
 public abstract class LivingEntityReloadMixin {
@@ -45,13 +47,24 @@ public abstract class LivingEntityReloadMixin {
     @Unique
     private long tacz_attributes$originalTimestamp = -1;
 
+    // === tickReloadState() ===
+
     /**
      * tickReloadState() の実行前に、リロードタイムスタンプをスケーリングする。
      * reloadSpeedModifier が 2.0 なら、経過時間が2倍に見え、リロードが2倍速くなる。
+     * また、ShooterContext を設定してマガジン容量属性が効くようにする。
      */
     @Inject(method = "tickReloadState", at = @At("HEAD"), remap = false)
     private void tacz_attributes$scaleTimestamp(CallbackInfoReturnable<ReloadState> cir) {
         tacz_attributes$originalTimestamp = -1;
+
+        // マガジン容量用の ShooterContext を設定
+        if (shooter != null) {
+            ShooterContext.set(shooter);
+        }
+
+        // リロード処理中フラグを設定（リロード時弾薬非消費・追加弾薬用）
+        ReloadFinishingContext.set();
 
         if (data.reloadTimestamp == -1) return;
 
@@ -69,9 +82,13 @@ public abstract class LivingEntityReloadMixin {
     /**
      * tickReloadState() の実行後に、オリジナルのタイムスタンプを復元する。
      * リロードが完了した場合（reloadTimestamp が -1 に設定された場合）は復元しない。
+     * また、ShooterContext をクリアする。
      */
     @Inject(method = "tickReloadState", at = @At("RETURN"), remap = false)
     private void tacz_attributes$restoreTimestamp(CallbackInfoReturnable<ReloadState> cir) {
+        ShooterContext.clear();
+        ReloadFinishingContext.clear();
+
         if (tacz_attributes$originalTimestamp == -1) return;
 
         // リロードが完了していない場合のみ復元
@@ -79,6 +96,27 @@ public abstract class LivingEntityReloadMixin {
             data.reloadTimestamp = tacz_attributes$originalTimestamp;
         }
         tacz_attributes$originalTimestamp = -1;
+    }
+
+    // === reload() ===
+
+    /**
+     * reload() の実行前に ShooterContext を設定する。
+     * リロード開始時にも getAmmoAmount() が呼ばれる可能性があるため。
+     */
+    @Inject(method = "reload", at = @At("HEAD"), remap = false)
+    private void tacz_attributes$setContextOnReload(CallbackInfo ci) {
+        if (shooter != null) {
+            ShooterContext.set(shooter);
+        }
+    }
+
+    /**
+     * reload() の実行後に ShooterContext をクリアする。
+     */
+    @Inject(method = "reload", at = @At("RETURN"), remap = false)
+    private void tacz_attributes$clearContextOnReload(CallbackInfo ci) {
+        ShooterContext.clear();
     }
 
     @Unique

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/ModernKineticGunScriptAPIMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/ModernKineticGunScriptAPIMixin.java
@@ -1,0 +1,205 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.github.leopoko.tacz_attributes.util.ReloadFinishingContext;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.item.ModernKineticGunScriptAPI;
+import com.tacz.guns.util.AttachmentDataUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * ModernKineticGunScriptAPI に対する属性適用Mixin。
+ * <p>
+ * 以下の3つの機能を提供する:
+ * 1. 射撃時弾薬非消費（reduceAmmoOnce の HEAD）
+ * 2. リロード時弾薬非消費（consumeAmmoFromPlayer の HEAD）
+ * 3. リロード時追加弾薬（putAmmoInMagazine の RETURN）
+ */
+@Mixin(ModernKineticGunScriptAPI.class)
+public class ModernKineticGunScriptAPIMixin {
+
+    @Shadow(remap = false)
+    private LivingEntity shooter;
+
+    @Shadow(remap = false)
+    private ItemStack itemStack;
+
+    // === 1. 射撃時弾薬非消費 ===
+
+    @Inject(method = "reduceAmmoOnce", at = @At("HEAD"), cancellable = true, remap = false)
+    private void tacz_attributes$ammoSaveChance(CallbackInfoReturnable<Boolean> cir) {
+        if (shooter == null) return;
+
+        double saveChance = tacz_attributes$getAmmoSaveChance();
+        if (saveChance <= 0) return;
+
+        if (shooter.getRandom().nextDouble() < saveChance) {
+            // true を返すことで「弾薬消費成功」と見せかけ、実際は消費しない
+            cir.setReturnValue(true);
+        }
+    }
+
+    // === 2. リロード時弾薬非消費 ===
+
+    /**
+     * リロード処理中に consumeAmmoFromPlayer() が呼ばれた場合、
+     * 確率でインベントリ弾薬を消費せずに neededAmount をそのまま返す（無料リロード）。
+     */
+    @Inject(method = "consumeAmmoFromPlayer", at = @At("HEAD"), cancellable = true, remap = false)
+    private void tacz_attributes$reloadAmmoSave(int neededAmount, CallbackInfoReturnable<Integer> cir) {
+        if (!ReloadFinishingContext.isReloading()) return;
+        if (shooter == null) return;
+
+        double saveChance = tacz_attributes$getReloadAmmoSaveChance();
+        if (saveChance <= 0) return;
+
+        if (shooter.getRandom().nextDouble() < saveChance) {
+            // neededAmount を返すことで「全弾消費成功」と見せかけ、実際は消費しない
+            cir.setReturnValue(neededAmount);
+        }
+    }
+
+    // === 3. リロード時追加弾薬 ===
+
+    /**
+     * リロード処理中に putAmmoInMagazine() が完了した後、
+     * 確率で追加弾薬をマガジンに装填する（マガジン上限を超えてもよい）。
+     */
+    @Inject(method = "putAmmoInMagazine", at = @At("RETURN"), remap = false)
+    private void tacz_attributes$bonusAmmo(int amount, CallbackInfoReturnable<Integer> cir) {
+        if (!ReloadFinishingContext.isReloading()) return;
+        if (shooter == null) return;
+
+        double chance = tacz_attributes$getBonusAmmoChance();
+        if (chance <= 0) return;
+
+        if (shooter.getRandom().nextDouble() >= chance) return;
+
+        int bonusAmount = tacz_attributes$calculateBonusAmmoAmount();
+        if (bonusAmount <= 0) return;
+
+        // マガジン上限を超えて弾薬を追加（setCurrentAmmoCount で直接設定）
+        IGun iGun = IGun.getIGunOrNull(itemStack);
+        if (iGun == null) return;
+
+        int currentAmmo = iGun.getCurrentAmmoCount(itemStack);
+        iGun.setCurrentAmmoCount(itemStack, currentAmmo + bonusAmount);
+    }
+
+    // === ヘルパーメソッド ===
+
+    @Unique
+    private double tacz_attributes$getAmmoSaveChance() {
+        double globalChance = 0.0;
+        if (shooter.getAttributes().hasAttribute(CustomAttributes.AMMO_SAVE_CHANCE.get())) {
+            globalChance = shooter.getAttributeValue(CustomAttributes.AMMO_SAVE_CHANCE.get());
+        }
+
+        double typeChance = 0.0;
+        GunType gunType = GunTypeResolver.resolveFromItem(itemStack);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getAmmoSaveChanceAttribute().get();
+            if (shooter.getAttributes().hasAttribute(typeAttr)) {
+                typeChance = shooter.getAttributeValue(typeAttr);
+            }
+        }
+
+        return Math.min(1.0, globalChance + typeChance);
+    }
+
+    @Unique
+    private double tacz_attributes$getReloadAmmoSaveChance() {
+        double globalChance = 0.0;
+        if (shooter.getAttributes().hasAttribute(CustomAttributes.RELOAD_AMMO_SAVE_CHANCE.get())) {
+            globalChance = shooter.getAttributeValue(CustomAttributes.RELOAD_AMMO_SAVE_CHANCE.get());
+        }
+
+        double typeChance = 0.0;
+        GunType gunType = GunTypeResolver.resolveFromItem(itemStack);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getReloadAmmoSaveChanceAttribute().get();
+            if (shooter.getAttributes().hasAttribute(typeAttr)) {
+                typeChance = shooter.getAttributeValue(typeAttr);
+            }
+        }
+
+        return Math.min(1.0, globalChance + typeChance);
+    }
+
+    @Unique
+    private double tacz_attributes$getBonusAmmoChance() {
+        double globalChance = 0.0;
+        if (shooter.getAttributes().hasAttribute(CustomAttributes.BONUS_AMMO_CHANCE.get())) {
+            globalChance = shooter.getAttributeValue(CustomAttributes.BONUS_AMMO_CHANCE.get());
+        }
+
+        double typeChance = 0.0;
+        GunType gunType = GunTypeResolver.resolveFromItem(itemStack);
+        if (gunType != null) {
+            Attribute typeAttr = gunType.getBonusAmmoChanceAttribute().get();
+            if (shooter.getAttributes().hasAttribute(typeAttr)) {
+                typeChance = shooter.getAttributeValue(typeAttr);
+            }
+        }
+
+        return Math.min(1.0, globalChance + typeChance);
+    }
+
+    @Unique
+    private int tacz_attributes$calculateBonusAmmoAmount() {
+        GunType gunType = GunTypeResolver.resolveFromItem(itemStack);
+
+        // 固定数（全体 + 銃種別）
+        double fixedAmount = tacz_attributes$getAttributeSum(
+                CustomAttributes.BONUS_AMMO_AMOUNT.get(),
+                gunType != null ? gunType.getBonusAmmoAmountAttribute().get() : null);
+
+        // 割合（全体 + 銃種別、上限 1.0）
+        double percent = Math.min(1.0, tacz_attributes$getAttributeSum(
+                CustomAttributes.BONUS_AMMO_PERCENT.get(),
+                gunType != null ? gunType.getBonusAmmoPercentAttribute().get() : null));
+
+        // マガジン最大容量
+        int maxAmmo = tacz_attributes$getMaxAmmo();
+
+        return (int) Math.round(fixedAmount) + (int) Math.ceil(maxAmmo * percent);
+    }
+
+    @Unique
+    private double tacz_attributes$getAttributeSum(Attribute globalAttr, Attribute typeAttr) {
+        double global = 0.0;
+        if (shooter.getAttributes().hasAttribute(globalAttr)) {
+            global = shooter.getAttributeValue(globalAttr);
+        }
+
+        double type = 0.0;
+        if (typeAttr != null && shooter.getAttributes().hasAttribute(typeAttr)) {
+            type = shooter.getAttributeValue(typeAttr);
+        }
+
+        return global + type;
+    }
+
+    @Unique
+    private int tacz_attributes$getMaxAmmo() {
+        IGun iGun = IGun.getIGunOrNull(itemStack);
+        if (iGun == null) return 0;
+
+        ResourceLocation gunId = iGun.getGunId(itemStack);
+        return TimelessAPI.getCommonGunIndex(gunId)
+                .map(index -> AttachmentDataUtils.getAmmoCountWithAttachment(itemStack, index.getGunData()))
+                .orElse(0);
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/util/ReloadFinishingContext.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/util/ReloadFinishingContext.java
@@ -1,0 +1,29 @@
+package com.github.leopoko.tacz_attributes.util;
+
+/**
+ * リロード処理中であることを示す ThreadLocal フラグ。
+ * <p>
+ * LivingEntityReloadMixin の tickReloadState() の HEAD で set() を呼び、
+ * RETURN で clear() を呼ぶことで、consumeAmmoFromPlayer() や putAmmoInMagazine() が
+ * リロード処理のコンテキストで呼ばれているかどうかを判定する。
+ * <p>
+ * これにより、リロード時弾薬非消費やリロード時追加弾薬がボルト操作時に誤って発動することを防ぐ。
+ */
+public final class ReloadFinishingContext {
+
+    private static final ThreadLocal<Boolean> IS_RELOADING = ThreadLocal.withInitial(() -> false);
+
+    private ReloadFinishingContext() {}
+
+    public static void set() {
+        IS_RELOADING.set(true);
+    }
+
+    public static void clear() {
+        IS_RELOADING.remove();
+    }
+
+    public static boolean isReloading() {
+        return IS_RELOADING.get();
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/util/ShooterContext.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/util/ShooterContext.java
@@ -1,0 +1,44 @@
+package com.github.leopoko.tacz_attributes.util;
+
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import net.minecraft.world.entity.LivingEntity;
+
+import javax.annotation.Nullable;
+
+/**
+ * ThreadLocal を使って現在の操作プレイヤーと銃種をコンテキストとして保持するユーティリティ。
+ * <p>
+ * GunData.getAmmoAmount() などの共有データにプレイヤー固有の属性倍率を適用するために使用する。
+ * Mixin の HEAD で set() を呼び、RETURN で clear() を呼ぶことで安全にコンテキストを管理する。
+ */
+public final class ShooterContext {
+
+    private static final ThreadLocal<ContextData> CONTEXT = new ThreadLocal<>();
+
+    private ShooterContext() {}
+
+    /**
+     * コンテキストを設定する。プレイヤーのメインハンドから銃種を自動解決する。
+     */
+    public static void set(LivingEntity shooter) {
+        GunType gunType = GunTypeResolver.resolveFromItem(shooter.getMainHandItem());
+        CONTEXT.set(new ContextData(shooter, gunType));
+    }
+
+    /**
+     * コンテキストをクリアする。必ず finally ブロックや RETURN インジェクションで呼ぶこと。
+     */
+    public static void clear() {
+        CONTEXT.remove();
+    }
+
+    /**
+     * 現在のコンテキストを取得する。設定されていない場合は null。
+     */
+    @Nullable
+    public static ContextData get() {
+        return CONTEXT.get();
+    }
+
+    public record ContextData(LivingEntity shooter, @Nullable GunType gunType) {}
+}

--- a/src/main/resources/tacz_attributes.mixins.json
+++ b/src/main/resources/tacz_attributes.mixins.json
@@ -5,7 +5,10 @@
   "compatibilityLevel": "JAVA_17",
   "refmap": "tacz_attributes.refmap.json",
   "mixins": [
-    "LivingEntityReloadMixin"
+    "LivingEntityReloadMixin",
+    "LivingEntityBoltMixin",
+    "GunDataMixin",
+    "ModernKineticGunScriptAPIMixin"
   ],
   "client": [
     "ObjectAnimationRunnerMixin"


### PR DESCRIPTION
## 概要
- コッキング速度、マガジン容量、弾薬関連の新属性を全銃共通・銃種別で追加
- 合計12種の基礎属性 × 7銃種 = 84の銃種別属性を新規登録

## 追加属性

### 速度・容量系（乗算合成: 全体 × 銃種別）
- `bolt_action_speed` — コッキング速度倍率
- `magazine_capacity` — マガジン容量倍率

### 弾薬節約系（加算合成: min(上限, 全体 + 銃種別)）
- `ammo_save_chance` — 射撃時弾薬非消費確率
- `reload_ammo_save_chance` — リロード時インベントリ弾薬非消費確率

### キル時弾薬回復
- `ammo_recovery_chance` — 回復確率
- `ammo_recovery_amount` — 回復固定数
- `ammo_recovery_percent` — 回復マガジン容量比率

### リロード時追加弾薬
- `bonus_ammo_chance` — 追加確率
- `bonus_ammo_amount` — 追加固定数
- `bonus_ammo_percent` — 追加マガジン容量比率

## 新規ファイル
- `GunKillAmmoRecovery.java` — EntityKillByGunEventハンドラ
- `LivingEntityBoltMixin.java` — コッキング速度のタイムスタンプスケーリング
- `GunDataMixin.java` — マガジン容量倍率（ShooterContext経由）
- `ModernKineticGunScriptAPIMixin.java` — 弾薬非消費・リロード時弾薬非消費・追加弾薬
- `ShooterContext.java` — ThreadLocalプレイヤーコンテキスト
- `ReloadFinishingContext.java` — リロード処理中フラグ

## テスト計画
- [x] `./gradlew build` でコンパイル成功を確認
- [x] `runClient` で属性コマンドによる動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)