### PR TITLE
追加: 精度・反動・ヘッドショット・ノックバック・貫通・RPM・ADS速度・弾数・武器切替・バースト速度など23種の属性を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:<fileId>
 ```
 src/main/java/com/github/leopoko/tacz_attributes/
 ├── Tacz_attributes.java          # MODメインクラス (@Mod エントリポイント)
-├── GunDamageModifier.java        # 銃ダメージ倍率の適用 (EntityHurtByGunEvent)
+├── GunDamageModifier.java        # 銃ダメージ・ヘッドショット倍率の適用 (EntityHurtByGunEvent)
 ├── GunKillAmmoRecovery.java     # キル時弾薬回復の適用 (EntityKillByGunEvent)
+├── GunMovementSpeedHandler.java  # 銃装備時移動速度の適用 (TickEvent)
 ├── api/
 │   └── ISpeedModifiable.java     # アニメーション速度倍率のダックインターフェース
 ├── attribute/
@@ -58,8 +59,18 @@ src/main/java/com/github/leopoko/tacz_attributes/
 │   ├── LivingEntityBoltMixin.java       # コッキング速度の変更 (タイムスタンプスケーリング)
 │   ├── LivingEntityReloadMixin.java     # リロード速度の変更 (タイムスタンプスケーリング)
 │   ├── ModernKineticGunScriptAPIMixin.java # 弾薬非消費・リロード時弾薬非消費・追加弾薬の適用
-│   └── ObjectAnimationRunnerMixin.java  # アニメーション速度倍率のMixin
+│   ├── EntityKineticBulletMixin.java    # ノックバック・貫通数属性の適用 (EntityKineticBullet)
+│   ├── LivingEntityAimMixin.java        # ADS移行速度属性の適用 (LivingEntityAim, サーバー側)
+│   ├── LocalPlayerAimMixin.java         # ADS移行速度属性の適用 (LocalPlayerAim, クライアント側)
+│   ├── ObjectAnimationRunnerMixin.java  # アニメーション速度倍率のMixin
+│   ├── RecoilMixin.java                 # 反動属性の適用 (CameraSetupEvent, クライアント側)
+│   ├── BulletAmountMixin.java            # 弾数属性の適用 (ModernKineticGunScriptAPI)
+│   ├── ShootInaccuracyMixin.java        # 腰撃ち/ADS精度属性の適用 (ModernKineticGunScriptAPI)
+│   ├── ShootIntervalMixin.java          # 発射レート(RPM)属性の適用 (GunData)
+│   ├── LivingEntityDrawGunMixin.java    # 武器切替速度属性の適用 (LivingEntityDrawGun, サーバー側)
+│   └── GunItemRendererWrapperMixin.java # 武器切替アニメーション速度の適用 (GunItemRendererWrapper, クライアント側)
 └── util/
+    ├── FireModeHelper.java       # FireMode別属性の解決ユーティリティ
     ├── GunTypeResolver.java      # gunId/ItemStack → GunType 解決ユーティリティ
     ├── ReloadFinishingContext.java # リロード処理中フラグ管理 (ThreadLocal)
     └── ShooterContext.java       # ThreadLocalによるプレイヤーコンテキスト管理
@@ -83,32 +94,194 @@ src/main/java/com/github/leopoko/tacz_attributes/
 | BONUS_AMMO_CHANCE | `bonus_ammo_chance` | 0.0 | 0.0〜1.0 | リロード完了時に追加弾薬が装填される確率 |
 | BONUS_AMMO_AMOUNT | `bonus_ammo_amount` | 0.0 | 0.0〜100.0 | 追加装填される弾薬の固定数 |
 | BONUS_AMMO_PERCENT | `bonus_ammo_percent` | 0.0 | 0.0〜1.0 | 追加装填される弾薬のマガジン容量比率 |
+| HIP_FIRE_ACCURACY | `hip_fire_accuracy` | 1.0 | 0.01〜100.0 | 腰撃ち精度倍率（高い値=高精度） |
+| ADS_ACCURACY | `ads_accuracy` | 1.0 | 0.01〜100.0 | ADS精度倍率（高い値=高精度） |
+| HIP_FIRE_DAMAGE | `hip_fire_damage` | 1.0 | 0.0〜1024.0 | 腰撃ちダメージ倍率 |
+| ADS_DAMAGE | `ads_damage` | 1.0 | 0.0〜1024.0 | ADSダメージ倍率 |
+| AUTO_DAMAGE | `auto_damage` | 1.0 | 0.0〜1024.0 | フルオートダメージ倍率 |
+| SEMI_DAMAGE | `semi_damage` | 1.0 | 0.0〜1024.0 | セミオートダメージ倍率 |
+| BURST_DAMAGE | `burst_damage` | 1.0 | 0.0〜1024.0 | バーストダメージ倍率 |
+| AUTO_ACCURACY | `auto_accuracy` | 1.0 | 0.01〜100.0 | フルオート精度倍率 |
+| SEMI_ACCURACY | `semi_accuracy` | 1.0 | 0.01〜100.0 | セミオート精度倍率 |
+| BURST_ACCURACY | `burst_accuracy` | 1.0 | 0.01〜100.0 | バースト精度倍率 |
+| RECOIL | `recoil` | 1.0 | 0.0〜100.0 | 全般反動倍率 |
+| VERTICAL_RECOIL | `vertical_recoil` | 1.0 | 0.0〜100.0 | 縦反動倍率 |
+| HORIZONTAL_RECOIL | `horizontal_recoil` | 1.0 | 0.0〜100.0 | 横反動倍率 |
+| ADS_RECOIL | `ads_recoil` | 1.0 | 0.0〜100.0 | ADS反動倍率 |
+| ADS_VERTICAL_RECOIL | `ads_vertical_recoil` | 1.0 | 0.0〜100.0 | ADS縦反動倍率 |
+| ADS_HORIZONTAL_RECOIL | `ads_horizontal_recoil` | 1.0 | 0.0〜100.0 | ADS横反動倍率 |
+| HIP_FIRE_RECOIL | `hip_fire_recoil` | 1.0 | 0.0〜100.0 | 腰撃ち反動倍率 |
+| HIP_FIRE_VERTICAL_RECOIL | `hip_fire_vertical_recoil` | 1.0 | 0.0〜100.0 | 腰撃ち縦反動倍率 |
+| HIP_FIRE_HORIZONTAL_RECOIL | `hip_fire_horizontal_recoil` | 1.0 | 0.0〜100.0 | 腰撃ち横反動倍率 |
+| GUN_MOVEMENT_SPEED | `gun_movement_speed` | 1.0 | 0.01〜10.0 | 銃装備時移動速度倍率 |
+| HEADSHOT_MULTIPLIER | `headshot_multiplier` | 1.0 | 0.0〜100.0 | ヘッドショット倍率 |
+| KNOCKBACK_MULTIPLIER | `knockback_multiplier` | 1.0 | 0.0〜100.0 | ノックバック倍率 |
+| KNOCKBACK_BASE | `knockback_base` | 0.0 | 0.0〜100.0 | ノックバック基本値（加算） |
+| PIERCE_MULTIPLIER | `pierce_multiplier` | 1.0 | 0.01〜100.0 | 貫通数倍率 |
+| RPM_MULTIPLIER | `rpm_multiplier` | 1.0 | 0.01〜10.0 | 発射レート(RPM)倍率 |
+| ADS_SPEED | `ads_speed` | 1.0 | 0.01〜10.0 | ADS移行速度倍率 |
+| SEMI_BULLET_AMOUNT | `semi_bullet_amount` | 1.0 | 0.01〜100.0 | セミオート弾数倍率 |
+| AUTO_BULLET_AMOUNT | `auto_bullet_amount` | 1.0 | 0.01〜100.0 | フルオート弾数倍率 |
+| BURST_BULLET_AMOUNT | `burst_bullet_amount` | 1.0 | 0.01〜100.0 | バースト弾数倍率 |
+| DRAW_SPEED | `draw_speed` | 1.0 | 0.01〜10.0 | 武器切替速度倍率（取り出し・しまい両方） |
 
 ### 銃種別
 
 ダメージ・リロード速度・コッキング速度・マガジン容量は乗算合成（最終倍率 = 全体 × 銃種別）。
 確率・数量系は加算合成（最終値 = min(上限, 全体 + 銃種別)）。
 
-各銃種（PISTOL, SNIPER, RIFLE, SHOTGUN, SMG, RPG, MG）ごとに以下の属性が存在する:
+各銃種（PISTOL, SNIPER, RIFLE, SHOTGUN, SMG, RPG, MG）に以下の属性が存在する:
 
-| カテゴリ | 属性サフィックス | 命名例（PISTOL） |
-|---------|----------------|-----------------|
-| ダメージ | `_damage` | `pistol_damage` |
-| リロード速度 | `_reload_speed` | `pistol_reload_speed` |
-| コッキング速度 | `_bolt_action_speed` | `pistol_bolt_action_speed` |
-| マガジン容量 | `_magazine_capacity` | `pistol_magazine_capacity` |
-| 射撃時弾薬非消費確率 | `_ammo_save_chance` | `pistol_ammo_save_chance` |
-| キル時弾薬回復確率 | `_ammo_recovery_chance` | `pistol_ammo_recovery_chance` |
-| キル時弾薬回復量（固定） | `_ammo_recovery_amount` | `pistol_ammo_recovery_amount` |
-| キル時弾薬回復量（割合） | `_ammo_recovery_percent` | `pistol_ammo_recovery_percent` |
-| リロード時弾薬非消費確率 | `_reload_ammo_save_chance` | `pistol_reload_ammo_save_chance` |
-| リロード時追加弾薬確率 | `_bonus_ammo_chance` | `pistol_bonus_ammo_chance` |
-| リロード時追加弾薬量（固定） | `_bonus_ammo_amount` | `pistol_bonus_ammo_amount` |
-| リロード時追加弾薬量（割合） | `_bonus_ammo_percent` | `pistol_bonus_ammo_percent` |
+| カテゴリ | 属性サフィックス | 範囲 |
+|---------|----------------|------|
+| ダメージ | `_damage` | 0.0〜1024.0 |
+| リロード速度 | `_reload_speed` | 0.1〜20.0 |
+| コッキング速度 | `_bolt_action_speed` | 0.1〜20.0 |
+| マガジン容量 | `_magazine_capacity` | 0.1〜100.0 |
+| 射撃時弾薬非消費確率 | `_ammo_save_chance` | 0.0〜1.0 |
+| キル時弾薬回復確率 | `_ammo_recovery_chance` | 0.0〜1.0 |
+| キル時弾薬回復量（固定） | `_ammo_recovery_amount` | 0.0〜100.0 |
+| キル時弾薬回復量（割合） | `_ammo_recovery_percent` | 0.0〜1.0 |
+| リロード時弾薬非消費確率 | `_reload_ammo_save_chance` | 0.0〜1.0 |
+| リロード時追加弾薬確率 | `_bonus_ammo_chance` | 0.0〜1.0 |
+| リロード時追加弾薬量（固定） | `_bonus_ammo_amount` | 0.0〜100.0 |
+| リロード時追加弾薬量（割合） | `_bonus_ammo_percent` | 0.0〜1.0 |
+| 腰撃ち精度 | `_hip_fire_accuracy` | 0.01〜100.0 |
+| ADS精度 | `_ads_accuracy` | 0.01〜100.0 |
+| 腰撃ちダメージ | `_hip_fire_damage` | 0.0〜1024.0 |
+| ADSダメージ | `_ads_damage` | 0.0〜1024.0 |
+| フルオートダメージ | `_auto_damage` | 0.0〜1024.0 |
+| セミオートダメージ | `_semi_damage` | 0.0〜1024.0 |
+| バーストダメージ | `_burst_damage` | 0.0〜1024.0 |
+| フルオート精度 | `_auto_accuracy` | 0.01〜100.0 |
+| セミオート精度 | `_semi_accuracy` | 0.01〜100.0 |
+| バースト精度 | `_burst_accuracy` | 0.01〜100.0 |
+| 全般反動 | `_recoil` | 0.0〜100.0 |
+| 縦反動 | `_vertical_recoil` | 0.0〜100.0 |
+| 横反動 | `_horizontal_recoil` | 0.0〜100.0 |
+| ADS反動 | `_ads_recoil` | 0.0〜100.0 |
+| ADS縦反動 | `_ads_vertical_recoil` | 0.0〜100.0 |
+| ADS横反動 | `_ads_horizontal_recoil` | 0.0〜100.0 |
+| 腰撃ち反動 | `_hip_fire_recoil` | 0.0〜100.0 |
+| 腰撃ち縦反動 | `_hip_fire_vertical_recoil` | 0.0〜100.0 |
+| 腰撃ち横反動 | `_hip_fire_horizontal_recoil` | 0.0〜100.0 |
+| 移動速度 | `_gun_movement_speed` | 0.01〜10.0 |
+| ヘッドショット倍率 | `_headshot_multiplier` | 0.0〜100.0 |
+| ノックバック倍率 | `_knockback_multiplier` | 0.0〜100.0 |
+| ノックバック基本値 | `_knockback_base` | 0.0〜100.0 |
+| 貫通数倍率 | `_pierce_multiplier` | 0.01〜100.0 |
+| RPM倍率 | `_rpm_multiplier` | 0.01〜10.0 |
+| ADS速度 | `_ads_speed` | 0.01〜10.0 |
+| セミオート弾数 | `_semi_bullet_amount` | 0.01〜100.0 |
+| フルオート弾数 | `_auto_bullet_amount` | 0.01〜100.0 |
+| バースト弾数 | `_burst_bullet_amount` | 0.01〜100.0 |
+| 武器切替速度 | `_draw_speed` | 0.01〜10.0 |
 
+例: `pistol_auto_damage`, `sniper_semi_accuracy`, `rifle_vertical_recoil`, `smg_rpm_multiplier` 等。
 銃種別属性のデフォルト値は倍率系がすべて 1.0（変更なし）、確率・数量系が 0.0（発動なし）。
-範囲はダメージ: 0.0〜1024.0、速度系: 0.1〜20.0、マガジン容量: 0.1〜100.0、確率: 0.0〜1.0、数量: 0.0〜100.0。
 銃種は TaCZ の `GunTabType` に準拠し、`GunType` enum で管理される。
+
+### 精度属性の計算式
+
+`最終inaccuracy = 基本inaccuracy / (全体精度 × 銃種別精度 × モード全体精度 × モード銃種別精度)`
+
+- 精度 2.0 → inaccuracy が半分（より高精度）
+- 精度 0.5 → inaccuracy が2倍（より低精度）
+- ADS中は `ads_accuracy` / 腰撃ち時は `hip_fire_accuracy` が適用される
+- 射撃モードに応じて `auto_accuracy` / `semi_accuracy` / `burst_accuracy` が適用される
+
+### ダメージ属性の計算式
+
+`最終ダメージ = 基本ダメージ × gun_damage × 銃種別damage × (ads/hip)ダメージ × 銃種別(ads/hip) × モードダメージ × 銃種別モードダメージ`
+
+- ADS中は `ads_damage` / 腰撃ち時は `hip_fire_damage` が適用される
+- 射撃モードに応じて `auto_damage` / `semi_damage` / `burst_damage` が適用される
+- ADS判定は弾着時の `IGunOperator.getSynIsAiming()` で行う
+- FireMode判定は `IGun.getFireMode(ItemStack)` で行う
+
+### 反動属性の計算式
+
+`pitch_modifier = TaCZ元modifier × 全般反動 × 縦反動 × (ADS/腰撃ち)反動 × (ADS/腰撃ち)縦反動 × 銃種全般反動 × 銃種縦反動 × 銃種(ADS/腰撃ち)反動 × 銃種(ADS/腰撃ち)縦反動`
+
+`yaw_modifier = TaCZ元modifier × 全般反動 × 横反動 × (ADS/腰撃ち)反動 × (ADS/腰撃ち)横反動 × 銃種全般反動 × 銃種横反動 × 銃種(ADS/腰撃ち)反動 × 銃種(ADS/腰撃ち)横反動`
+
+- 反動 0.5 → リコイルが半分
+- 反動 2.0 → リコイルが2倍
+- 反動 0.0 → 反動なし
+- ADS判定は `IGunOperator.getSynIsAiming()` で行う
+- CameraSetupEvent.initialCameraRecoil() 内の genPitchSplineFunction / genYawSplineFunction を @ModifyArg で適用
+
+### ヘッドショット倍率の計算式
+
+`最終HS倍率 = TaCZ元HS倍率 × headshot_multiplier × 銃種別headshot_multiplier`
+
+- ヘッドショット倍率 2.0 → HSダメージ2倍
+- EntityHurtByGunEvent.Pre 内で setHeadshotMultiplier() により適用
+
+### 移動速度の計算式
+
+`最終移動速度 = TaCZ処理後の速度 × (gun_movement_speed × 銃種別gun_movement_speed)`
+
+- 銃を持っている場合のみ適用
+- MULTIPLY_TOTAL の AttributeModifier として MOVEMENT_SPEED に追加
+- TaCZの重量ペナルティ・ADS/リロード減速の上に乗算される
+
+### ノックバックの計算式
+
+`最終ノックバック = (TaCZ元knockback + knockback_base + 銃種別knockback_base) × knockback_multiplier × 銃種別knockback_multiplier`
+
+- TaCZの銃はデフォルトでknockback=0のため、`knockback_base` で基本値を加算する必要がある
+- knockback_base 0.4 → バニラ攻撃相当のノックバックを追加
+- knockback_multiplier 2.0 → ノックバック2倍
+- EntityKineticBullet.onHitEntity() 内の KnockBackModifier.setKnockBackStrength() を @ModifyArg で適用
+
+### 貫通数の計算式
+
+`最終貫通数 = max(1, (int)(TaCZ元pierce × pierce_multiplier × 銃種別pierce_multiplier))`
+
+- 貫通数 2.0 → 貫通数2倍（小数点以下切り捨て、最低1）
+- EntityKineticBullet コンストラクタ末尾で @Inject して適用
+
+### 発射レート(RPM)の計算式
+
+`最終射撃間隔 = max(1, TaCZ元インターバル / (rpm_multiplier × 銃種別rpm_multiplier))`
+
+- RPM倍率 2.0 → 射撃間隔半分 → 2倍速射
+- RPM倍率 0.5 → 射撃間隔2倍 → 半分の速度
+- GunData.getShootInterval() の戻り値を @Inject(RETURN) で変更
+
+### ADS移行速度の計算式
+
+`最終aimTime = Math.max(0, aimTime) / (ads_speed × 銃種別ads_speed)`
+
+- ADS速度 2.0 → ADS移行時間半分 → 2倍速でエイム
+- ADS速度 0.5 → ADS移行時間2倍 → 遅いエイム
+- サーバー側: LivingEntityAim.tickAimingProgress() 内の Math.max(0, aimTime) を @Redirect して適用
+- クライアント側: LocalPlayerAim.getAlphaProgress() 内の Math.max(0, aimTime) を @Redirect して適用（ADSアニメーション）
+
+### 弾数倍率の計算式
+
+セミオート/フルオート:
+`最終bulletAmount = max(1, (int)(bulletAmount × semi/auto_bullet_amount × 銃種別semi/auto_bullet_amount))`
+
+バースト:
+`最終cycles = max(1, (int)(cycles × burst_bullet_amount × 銃種別burst_bullet_amount))`
+
+- セミオート弾数 2.0 → 1発のトリガーで発射される弾丸数が2倍
+- フルオート弾数 2.0 → 1ティックで発射される弾丸数が2倍
+- バースト弾数 2.0 → バーストで発射される弾数が2倍（3点バースト → 6点バースト）
+- ModernKineticGunScriptAPI.shootOnce() 内の bulletAmount/cycles を @ModifyVariable で変更
+
+### 武器切替速度の計算式
+
+`最終holster時間 = TaCZ元putAwayTime / (draw_speed × 銃種別draw_speed)`
+`最終draw時間 = TaCZ元drawTime / (draw_speed × 銃種別draw_speed)`
+
+- draw_speed 2.0 → 取り出し・しまい時間が半分 → 2倍速で武器切替
+- draw_speed 0.5 → 取り出し・しまい時間が2倍 → 半分の速度
+- 銃種は切り替え先の武器（メインハンド）で判定
+- サーバー側: LivingEntityDrawGun.draw() の TAIL で drawTimestamp をスケーリング + getDrawCoolDown() の RETURN でdraw時間デルタを減算
+- クライアント側: GunItemRendererWrapper.getPutAwayTime() の戻り値をスケーリング（アニメーション・音声タイミングに反映）
 
 ## MOD ID
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ src/main/java/com/github/leopoko/tacz_attributes/
 │   ├── EntityAttributeSetup.java # プレイヤーへの属性バインド
 │   └── GunType.java              # 銃種enum・銃種別属性の定義
 ├── client/
+│   ├── DrawAnimationSpeedHandler.java   # クライアント側drawアニメーション速度同期
 │   └── ReloadAnimationSpeedHandler.java # クライアント側リロード/ボルトアニメーション速度同期
 ├── mixin/
 │   ├── GunDataMixin.java                # マガジン容量倍率の適用 (ShooterContext連携)
@@ -64,7 +65,8 @@ src/main/java/com/github/leopoko/tacz_attributes/
 │   ├── LocalPlayerAimMixin.java         # ADS移行速度属性の適用 (LocalPlayerAim, クライアント側)
 │   ├── ObjectAnimationRunnerMixin.java  # アニメーション速度倍率のMixin
 │   ├── RecoilMixin.java                 # 反動属性の適用 (CameraSetupEvent, クライアント側)
-│   ├── BulletAmountMixin.java            # 弾数属性の適用 (ModernKineticGunScriptAPI)
+│   ├── BulletAmountMixin.java            # 弾数・バースト速度属性の適用 (ModernKineticGunScriptAPI, サーバー側)
+│   ├── LocalPlayerShootMixin.java       # バースト弾数・速度のクライアント側同期 (LocalPlayerShoot)
 │   ├── ShootInaccuracyMixin.java        # 腰撃ち/ADS精度属性の適用 (ModernKineticGunScriptAPI)
 │   ├── ShootIntervalMixin.java          # 発射レート(RPM)属性の適用 (GunData)
 │   ├── LivingEntityDrawGunMixin.java    # 武器切替速度属性の適用 (LivingEntityDrawGun, サーバー側)
@@ -124,6 +126,7 @@ src/main/java/com/github/leopoko/tacz_attributes/
 | AUTO_BULLET_AMOUNT | `auto_bullet_amount` | 1.0 | 0.01〜100.0 | フルオート弾数倍率 |
 | BURST_BULLET_AMOUNT | `burst_bullet_amount` | 1.0 | 0.01〜100.0 | バースト弾数倍率 |
 | DRAW_SPEED | `draw_speed` | 1.0 | 0.01〜10.0 | 武器切替速度倍率（取り出し・しまい両方） |
+| BURST_SPEED | `burst_speed` | 1.0 | 0.01〜10.0 | バースト内射撃間隔速度倍率（高い値=速いバースト） |
 
 ### 銃種別
 
@@ -176,6 +179,7 @@ src/main/java/com/github/leopoko/tacz_attributes/
 | フルオート弾数 | `_auto_bullet_amount` | 0.01〜100.0 |
 | バースト弾数 | `_burst_bullet_amount` | 0.01〜100.0 |
 | 武器切替速度 | `_draw_speed` | 0.01〜10.0 |
+| バースト速度 | `_burst_speed` | 0.01〜10.0 |
 
 例: `pistol_auto_damage`, `sniper_semi_accuracy`, `rifle_vertical_recoil`, `smg_rpm_multiplier` 等。
 銃種別属性のデフォルト値は倍率系がすべて 1.0（変更なし）、確率・数量系が 0.0（発動なし）。
@@ -270,7 +274,18 @@ src/main/java/com/github/leopoko/tacz_attributes/
 - セミオート弾数 2.0 → 1発のトリガーで発射される弾丸数が2倍
 - フルオート弾数 2.0 → 1ティックで発射される弾丸数が2倍
 - バースト弾数 2.0 → バーストで発射される弾数が2倍（3点バースト → 6点バースト）
-- ModernKineticGunScriptAPI.shootOnce() 内の bulletAmount/cycles を @ModifyVariable で変更
+- サーバー側: ModernKineticGunScriptAPI.shootOnce() 内の bulletAmount/cycles を @ModifyVariable で変更
+- クライアント側: LocalPlayerShoot.doShoot() 内の cycles を @ModifyVariable で変更（反動・音声の同期）
+
+### バースト速度の計算式
+
+`最終burstShootInterval = TaCZ元interval / (burst_speed × 銃種別burst_speed)`
+
+- burst_speed 2.0 → バースト内の射撃間隔が半分 → より速いバースト
+- burst_speed 0.5 → バースト内の射撃間隔が2倍 → より遅いバースト
+- バーストモード時のみ適用
+- サーバー側: ModernKineticGunScriptAPI.shootOnce() 内の burstShootInterval (long ordinal 0) を @ModifyVariable で変更
+- クライアント側: LocalPlayerShoot.doShoot() 内の burstShootInterval (long ordinal 0) を @ModifyVariable で変更（音声・反動タイミングに反映）
 
 ### 武器切替速度の計算式
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,271 @@
+# TaCZ Attributes
+
+**Minecraft Forge 1.20.1** | **License: MIT**
+
+---
+
+## English
+
+### Overview
+
+**TaCZ Attributes** is an addon mod for [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero) that brings an RPG-style attribute system to firearms. Customize every aspect of gun behavior — damage, accuracy, recoil, fire rate, movement speed, and more — through Minecraft's native attribute system.
+
+This means you can modify gun stats using **commands**, **equipment (curios/trinkets)**, **enchantments**, **potions**, or any other mod that interacts with vanilla attributes. Perfect for RPG servers, progression systems, and custom modpacks.
+
+### Features
+
+**33 global attributes** that apply to all guns, plus **33 per-gun-type attributes** for each of the 7 gun types (Pistol, Sniper, Rifle, Shotgun, SMG, RPG, MG) — totaling **264 customizable attributes**.
+
+#### Damage & Combat
+- **Gun Damage** — Global bullet damage multiplier
+- **Hip Fire / ADS Damage** — Damage multiplier based on aiming state
+- **Semi / Auto / Burst Damage** — Damage multiplier based on fire mode
+- **Headshot Multiplier** — Scale headshot bonus damage
+- **Knockback Multiplier & Base** — Add and scale bullet knockback
+- **Pierce Multiplier** — Scale bullet penetration count
+
+#### Accuracy & Recoil
+- **Hip Fire / ADS Accuracy** — Accuracy based on aiming state
+- **Semi / Auto / Burst Accuracy** — Accuracy based on fire mode
+- **Recoil (General / Vertical / Horizontal)** — Overall recoil control
+- **ADS Recoil (General / Vertical / Horizontal)** — Recoil while aiming
+- **Hip Fire Recoil (General / Vertical / Horizontal)** — Recoil while hip firing
+
+#### Speed & Handling
+- **Reload Speed** — Reload animation speed multiplier
+- **Bolt Action Speed** — Cocking/bolt action speed multiplier
+- **RPM Multiplier** — Fire rate multiplier
+- **ADS Speed** — Aim-down-sight transition speed
+- **Draw Speed** — Weapon switch speed (both draw and holster)
+- **Burst Speed** — Interval between shots in a burst
+- **Gun Movement Speed** — Movement speed while holding a gun
+
+#### Ammo & Magazine
+- **Magazine Capacity** — Magazine size multiplier
+- **Semi / Auto / Burst Bullet Amount** — Bullets per shot/burst multiplier
+- **Ammo Save Chance** — Chance to not consume ammo when firing
+- **Ammo Recovery Chance / Amount / Percent** — Recover ammo on kill
+- **Reload Ammo Save Chance** — Chance to not consume inventory ammo on reload
+- **Bonus Ammo Chance / Amount / Percent** — Extra ammo loaded on reload
+
+#### Gun Type System
+
+All attributes above also exist for each gun type. The final value is calculated as:
+
+`Final Value = Global Attribute × Gun Type Attribute`
+
+For example, setting `sniper_damage = 1.5` and `gun_damage = 1.2` results in sniper rifles dealing `1.8×` damage.
+
+### Usage Example
+
+```
+/attribute @p tacz_attributes:gun_damage base set 2.0
+/attribute @p tacz_attributes:sniper_headshot_multiplier base set 3.0
+/attribute @p tacz_attributes:rifle_recoil base set 0.5
+```
+
+### Dependencies
+
+- **Required**: [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero)
+- **Recommended**: [Apothic Attributes](https://www.curseforge.com/minecraft/mc-mods/apothic-attributes) — Allows attribute values beyond vanilla limits
+
+---
+
+## 日本語
+
+### 概要
+
+**TaCZ Attributes** は [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero) のアドオンMODで、銃にRPG的な属性システムを追加します。ダメージ、精度、反動、発射レート、移動速度など、銃のあらゆる挙動をMinecraftの属性システムで制御できます。
+
+つまり、**コマンド**、**装備品（Curios/トリンケット）**、**エンチャント**、**ポーション**など、バニラ属性と連携するあらゆるMODで銃のステータスを変更できます。RPGサーバー、成長システム、カスタムMODパックに最適です。
+
+### 特徴
+
+**33種の全銃共通属性** と、7銃種（ピストル、スナイパー、ライフル、ショットガン、SMG、RPG、MG）ごとに**33種の銃種別属性** — 合計 **264のカスタマイズ可能な属性**。
+
+#### ダメージ・戦闘
+- **銃ダメージ** — 全弾丸ダメージ倍率
+- **腰撃ち / ADS ダメージ** — エイム状態別ダメージ倍率
+- **セミ / フルオート / バースト ダメージ** — 射撃モード別ダメージ倍率
+- **ヘッドショット倍率** — ヘッドショットボーナスダメージの倍率
+- **ノックバック倍率・基本値** — 弾丸ノックバックの追加・倍率
+- **貫通数倍率** — 弾丸貫通数の倍率
+
+#### 精度・反動
+- **腰撃ち / ADS 精度** — エイム状態別の精度
+- **セミ / フルオート / バースト 精度** — 射撃モード別の精度
+- **反動（全般 / 縦 / 横）** — 全般的なリコイル制御
+- **ADS反動（全般 / 縦 / 横）** — ADS中のリコイル
+- **腰撃ち反動（全般 / 縦 / 横）** — 腰撃ち時のリコイル
+
+#### 速度・操作性
+- **リロード速度** — リロードアニメーション速度倍率
+- **コッキング速度** — ボルトアクション速度倍率
+- **RPM倍率** — 発射レート倍率
+- **ADS速度** — エイム移行速度
+- **武器切替速度** — 取り出し・しまい速度
+- **バースト速度** — バースト内の射撃間隔速度
+- **銃装備時移動速度** — 銃を持っている時の移動速度
+
+#### 弾薬・マガジン
+- **マガジン容量** — マガジンサイズ倍率
+- **セミ / フルオート / バースト 弾数** — 一度に発射する弾数の倍率
+- **弾薬非消費確率** — 射撃時に弾薬を消費しない確率
+- **キル時弾薬回復 確率 / 固定数 / 割合** — キル時に弾薬を回復
+- **リロード時弾薬非消費確率** — リロード時にインベントリ弾薬を消費しない確率
+- **追加弾薬 確率 / 固定数 / 割合** — リロード時に追加弾薬を装填
+
+#### 銃種別システム
+
+すべての属性は銃種ごとにも設定可能です：
+
+`最終値 = 全体属性 × 銃種別属性`
+
+例：`sniper_damage = 1.5` かつ `gun_damage = 1.2` の場合、スナイパーライフルは `1.8倍` のダメージ。
+
+### 使用例
+
+```
+/attribute @p tacz_attributes:gun_damage base set 2.0
+/attribute @p tacz_attributes:sniper_headshot_multiplier base set 3.0
+/attribute @p tacz_attributes:rifle_recoil base set 0.5
+```
+
+### 前提MOD
+
+- **必須**: [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero)
+- **推奨**: [Apothic Attributes](https://www.curseforge.com/minecraft/mc-mods/apothic-attributes) — バニラの制限を超えた属性値を設定可能
+
+---
+
+## 한국어
+
+### 개요
+
+**TaCZ Attributes**는 [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero)의 애드온 모드로, 총기에 RPG 스타일의 속성 시스템을 추가합니다. 데미지, 정확도, 반동, 발사 속도, 이동 속도 등 총기의 모든 동작을 마인크래프트의 기본 속성 시스템으로 제어할 수 있습니다.
+
+즉, **커맨드**, **장비 (Curios/트링킷)**, **인챈트**, **포션** 등 바닐라 속성과 연동하는 모든 모드로 총기 스탯을 변경할 수 있습니다. RPG 서버, 성장 시스템, 커스텀 모드팩에 최적입니다.
+
+### 특징
+
+**33종의 전체 총기 공통 속성**과 7가지 총기 유형(피스톨, 스나이퍼, 라이플, 샷건, SMG, RPG, MG)별 **33종의 유형별 속성** — 총 **264개의 커스터마이징 가능한 속성**.
+
+#### 데미지 & 전투
+- **총기 데미지** — 전체 탄환 데미지 배율
+- **힙파이어 / ADS 데미지** — 조준 상태별 데미지 배율
+- **세미 / 풀오토 / 버스트 데미지** — 발사 모드별 데미지 배율
+- **헤드샷 배율** — 헤드샷 보너스 데미지 스케일링
+- **넉백 배율 & 기본값** — 탄환 넉백 추가 및 배율
+- **관통수 배율** — 탄환 관통 수 배율
+
+#### 정확도 & 반동
+- **힙파이어 / ADS 정확도** — 조준 상태별 정확도
+- **세미 / 풀오토 / 버스트 정확도** — 발사 모드별 정확도
+- **반동 (전체 / 수직 / 수평)** — 전체적인 반동 제어
+- **ADS 반동 (전체 / 수직 / 수평)** — 조준 시 반동
+- **힙파이어 반동 (전체 / 수직 / 수평)** — 힙파이어 시 반동
+
+#### 속도 & 조작성
+- **리로드 속도** — 리로드 애니메이션 속도 배율
+- **볼트 액션 속도** — 코킹 속도 배율
+- **RPM 배율** — 발사 속도 배율
+- **ADS 속도** — 조준 전환 속도
+- **무기 전환 속도** — 무기 꺼내기/넣기 속도
+- **버스트 속도** — 버스트 내 발사 간격 속도
+- **총기 이동 속도** — 총기 소지 시 이동 속도
+
+#### 탄약 & 탄창
+- **탄창 용량** — 탄창 크기 배율
+- **세미 / 풀오토 / 버스트 탄수** — 한 번에 발사하는 탄수 배율
+- **탄약 절약 확률** — 발사 시 탄약을 소비하지 않을 확률
+- **킬 시 탄약 회복 확률 / 고정량 / 비율** — 킬 시 탄약 회복
+- **리로드 시 탄약 절약 확률** — 리로드 시 인벤토리 탄약을 소비하지 않을 확률
+- **추가 탄약 확률 / 고정량 / 비율** — 리로드 시 추가 탄약 장전
+
+#### 총기 유형 시스템
+
+모든 속성은 총기 유형별로도 설정할 수 있습니다:
+
+`최종값 = 전체 속성 × 유형별 속성`
+
+예시: `sniper_damage = 1.5`이고 `gun_damage = 1.2`이면, 스나이퍼 라이플은 `1.8배` 데미지.
+
+### 사용 예시
+
+```
+/attribute @p tacz_attributes:gun_damage base set 2.0
+/attribute @p tacz_attributes:sniper_headshot_multiplier base set 3.0
+/attribute @p tacz_attributes:rifle_recoil base set 0.5
+```
+
+### 의존 모드
+
+- **필수**: [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero)
+- **권장**: [Apothic Attributes](https://www.curseforge.com/minecraft/mc-mods/apothic-attributes) — 바닐라 제한을 넘는 속성 값 설정 가능
+
+---
+
+## 中文
+
+### 概述
+
+**TaCZ Attributes** 是 [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero) 的附属模组，为枪械添加了 RPG 风格的属性系统。通过 Minecraft 原生属性系统来控制枪械的方方面面——伤害、精准度、后坐力、射速、移动速度等。
+
+这意味着您可以通过**命令**、**装备（Curios/饰品）**、**附魔**、**药水**或任何与原版属性交互的模组来修改枪械属性。非常适合 RPG 服务器、成长系统和自定义整合包。
+
+### 特性
+
+**33 种全局通用属性**，加上 7 种枪械类型（手枪、狙击枪、步枪、霰弹枪、冲锋枪、火箭筒、机枪）各 **33 种类型专属属性** — 共计 **264 个可自定义的属性**。
+
+#### 伤害与战斗
+- **枪械伤害** — 全局子弹伤害倍率
+- **腰射 / 瞄准伤害** — 基于瞄准状态的伤害倍率
+- **半自动 / 全自动 / 点射伤害** — 基于射击模式的伤害倍率
+- **爆头倍率** — 爆头额外伤害的缩放
+- **击退倍率与基础值** — 添加和缩放子弹击退
+- **穿透数倍率** — 子弹穿透次数倍率
+
+#### 精准度与后坐力
+- **腰射 / 瞄准精准度** — 基于瞄准状态的精准度
+- **半自动 / 全自动 / 点射精准度** — 基于射击模式的精准度
+- **后坐力（综合 / 垂直 / 水平）** — 整体后坐力控制
+- **瞄准后坐力（综合 / 垂直 / 水平）** — 瞄准时的后坐力
+- **腰射后坐力（综合 / 垂直 / 水平）** — 腰射时的后坐力
+
+#### 速度与操控
+- **换弹速度** — 换弹动画速度倍率
+- **拉栓速度** — 栓动速度倍率
+- **RPM 倍率** — 射速倍率
+- **瞄准速度** — 瞄准切换速度
+- **切枪速度** — 武器掏出/收起速度
+- **点射速度** — 点射内射击间隔速度
+- **持枪移动速度** — 持枪时的移动速度
+
+#### 弹药与弹匣
+- **弹匣容量** — 弹匣大小倍率
+- **半自动 / 全自动 / 点射弹量** — 每次发射的子弹数倍率
+- **弹药节省概率** — 射击时不消耗弹药的概率
+- **击杀回弹 概率 / 固定量 / 比例** — 击杀时回复弹药
+- **换弹节省概率** — 换弹时不消耗背包弹药的概率
+- **额外弹药 概率 / 固定量 / 比例** — 换弹时额外装填弹药
+
+#### 枪械类型系统
+
+所有属性均可按枪械类型单独设置：
+
+`最终值 = 全局属性 × 类型属性`
+
+例如：`sniper_damage = 1.5` 且 `gun_damage = 1.2` 时，狙击枪造成 `1.8 倍` 伤害。
+
+### 使用示例
+
+```
+/attribute @p tacz_attributes:gun_damage base set 2.0
+/attribute @p tacz_attributes:sniper_headshot_multiplier base set 3.0
+/attribute @p tacz_attributes:rifle_recoil base set 0.5
+```
+
+### 依赖模组
+
+- **必需**: [Timeless and Classics Zero (TaCZ)](https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero)
+- **推荐**: [Apothic Attributes](https://www.curseforge.com/minecraft/mc-mods/apothic-attributes) — 允许设置超出原版限制的属性值

--- a/src/main/java/com/github/leopoko/tacz_attributes/GunDamageModifier.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/GunDamageModifier.java
@@ -2,8 +2,11 @@ package com.github.leopoko.tacz_attributes;
 
 import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
 import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.FireModeHelper;
 import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.event.common.EntityHurtByGunEvent;
+import com.tacz.guns.api.item.gun.FireMode;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -25,34 +28,80 @@ public class GunDamageModifier {
         LivingEntity attacker = event.getAttacker();
         if (attacker == null) return;
 
+        ResourceLocation gunId = event.getGunId();
+        GunType gunType = GunTypeResolver.resolve(gunId);
+
         // 全体ダメージ倍率
-        double globalModifier = 1.0;
-        if (attacker.getAttributes().hasAttribute(CustomAttributes.GUN_DAMAGE.get())) {
-            globalModifier = attacker.getAttributeValue(CustomAttributes.GUN_DAMAGE.get());
-        }
+        double globalModifier = getAttributeValue(attacker, CustomAttributes.GUN_DAMAGE.get());
 
         // 銃種別ダメージ倍率
         double typeModifier = 1.0;
-        ResourceLocation gunId = event.getGunId();
-        GunType gunType = GunTypeResolver.resolve(gunId);
         if (gunType != null) {
-            Attribute typeAttr = gunType.getDamageAttribute().get();
-            if (attacker.getAttributes().hasAttribute(typeAttr)) {
-                typeModifier = attacker.getAttributeValue(typeAttr);
+            typeModifier = getAttributeValue(attacker, gunType.getDamageAttribute().get());
+        }
+
+        // ADS / 腰撃ちダメージ倍率
+        boolean isAds = IGunOperator.fromLivingEntity(attacker).getSynIsAiming();
+        double adsHipGlobal;
+        double adsHipType = 1.0;
+        if (isAds) {
+            adsHipGlobal = getAttributeValue(attacker, CustomAttributes.ADS_DAMAGE.get());
+            if (gunType != null) {
+                adsHipType = getAttributeValue(attacker, gunType.getAdsDamageAttribute().get());
+            }
+        } else {
+            adsHipGlobal = getAttributeValue(attacker, CustomAttributes.HIP_FIRE_DAMAGE.get());
+            if (gunType != null) {
+                adsHipType = getAttributeValue(attacker, gunType.getHipFireDamageAttribute().get());
             }
         }
 
-        double combinedModifier = globalModifier * typeModifier;
-        if (combinedModifier == 1.0) return;
+        // 射撃モード別ダメージ倍率
+        FireMode fireMode = FireModeHelper.getFireMode(attacker.getMainHandItem());
+        double fireModeGlobal = FireModeHelper.getAttributeValue(attacker, FireModeHelper.getGlobalDamageAttribute(fireMode));
+        double fireModeType = FireModeHelper.getAttributeValue(attacker, FireModeHelper.getTypeDamageAttribute(gunType, fireMode));
 
-        float modifiedDamage = (float) (event.getBaseAmount() * combinedModifier);
+        double combinedModifier = globalModifier * typeModifier * adsHipGlobal * adsHipType * fireModeGlobal * fireModeType;
+        if (combinedModifier != 1.0) {
+            float modifiedDamage = (float) (event.getBaseAmount() * combinedModifier);
 
-        if (!FMLEnvironment.production) {
-            LOGGER.info("[TaCZ Attributes] 銃ダメージ倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
-                    event.getBaseAmount(), modifiedDamage, globalModifier,
-                    gunType != null ? gunType.getTypeId() : "unknown", typeModifier);
+            if (!FMLEnvironment.production) {
+                LOGGER.info("[TaCZ Attributes] 銃ダメージ倍率適用: {} -> {} (全体: {}, 銃種[{}]: {}, {}: {}×{}, モード[{}]: {}×{})",
+                        event.getBaseAmount(), modifiedDamage, globalModifier,
+                        gunType != null ? gunType.getTypeId() : "unknown", typeModifier,
+                        isAds ? "ADS" : "腰撃ち", adsHipGlobal, adsHipType,
+                        fireMode != null ? fireMode.name() : "unknown", fireModeGlobal, fireModeType);
+            }
+
+            event.setBaseAmount(modifiedDamage);
         }
 
-        event.setBaseAmount(modifiedDamage);
+        // ヘッドショット倍率の適用
+        if (event.isHeadShot()) {
+            double hsGlobal = getAttributeValue(attacker, CustomAttributes.HEADSHOT_MULTIPLIER.get());
+            double hsType = 1.0;
+            if (gunType != null) {
+                hsType = getAttributeValue(attacker, gunType.getHeadshotMultiplierAttribute().get());
+            }
+            double hsCombined = hsGlobal * hsType;
+            if (hsCombined != 1.0) {
+                float newHsMultiplier = (float) (event.getHeadshotMultiplier() * hsCombined);
+
+                if (!FMLEnvironment.production) {
+                    LOGGER.info("[TaCZ Attributes] ヘッドショット倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
+                            event.getHeadshotMultiplier(), newHsMultiplier, hsGlobal,
+                            gunType != null ? gunType.getTypeId() : "unknown", hsType);
+                }
+
+                event.setHeadshotMultiplier(newHsMultiplier);
+            }
+        }
+    }
+
+    private static double getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
     }
 }

--- a/src/main/java/com/github/leopoko/tacz_attributes/GunMovementSpeedHandler.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/GunMovementSpeedHandler.java
@@ -1,0 +1,84 @@
+package com.github.leopoko.tacz_attributes;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.item.IGun;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.UUID;
+
+/**
+ * 銃装備時の移動速度属性を適用するイベントハンドラ。
+ * <p>
+ * プレイヤーが銃を持っている間、gun_movement_speed 属性と銃種別の移動速度属性に基づき
+ * MULTIPLY_TOTAL の AttributeModifier を MOVEMENT_SPEED に適用する。
+ * TaCZ 自身の速度修正（重量・エイム・リロード）の上に乗算される。
+ */
+@Mod.EventBusSubscriber(modid = Tacz_attributes.MODID)
+public class GunMovementSpeedHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final UUID TACZ_ATTR_SPEED_MODIFIER_UUID = UUID.fromString("a3c7e8f1-5d2b-4a96-b8e3-1f7d9c6a2e04");
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        if (event.side != LogicalSide.SERVER) return;
+
+        Player player = event.player;
+        AttributeInstance speedAttr = player.getAttribute(Attributes.MOVEMENT_SPEED);
+        if (speedAttr == null) return;
+
+        // 既存のModifierを除去
+        speedAttr.removeModifier(TACZ_ATTR_SPEED_MODIFIER_UUID);
+
+        // 銃を持っていない場合は何もしない
+        ItemStack mainHand = player.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(mainHand);
+        if (iGun == null) return;
+
+        GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
+        double globalSpeed = getAttributeValue(player, CustomAttributes.GUN_MOVEMENT_SPEED.get());
+        double typeSpeed = 1.0;
+        if (gunType != null) {
+            typeSpeed = getAttributeValue(player, gunType.getGunMovementSpeedAttribute().get());
+        }
+        double combined = globalSpeed * typeSpeed;
+
+        if (combined == 1.0) return;
+
+        // MULTIPLY_TOTAL: 最終値 *= (1 + amount)
+        // combined=0.8 → amount=-0.2 → 最終値 *= 0.8
+        double amount = combined - 1.0;
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] 移動速度倍率適用: combined={} (全体: {}, 銃種[{}]: {})",
+                    combined, globalSpeed,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeSpeed);
+        }
+
+        speedAttr.addTransientModifier(new AttributeModifier(
+                TACZ_ATTR_SPEED_MODIFIER_UUID, "TaCZ Attributes Gun Movement Speed",
+                amount, AttributeModifier.Operation.MULTIPLY_TOTAL));
+    }
+
+    private static double getAttributeValue(Player player, Attribute attribute) {
+        if (player.getAttributes().hasAttribute(attribute)) {
+            return player.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
@@ -67,6 +67,126 @@ public class CustomAttributes {
     public static final RegistryObject<Attribute> BONUS_AMMO_PERCENT = ATTRIBUTES.register("bonus_ammo_percent",
             () -> new RangedAttribute("attribute.tacz_attributes.bonus_ammo_percent", 0.0, 0.0, 1.0).setSyncable(true));
 
+    // 腰撃ち精度倍率（高い値 = 高精度 = 低inaccuracy）
+    public static final RegistryObject<Attribute> HIP_FIRE_ACCURACY = ATTRIBUTES.register("hip_fire_accuracy",
+            () -> new RangedAttribute("attribute.tacz_attributes.hip_fire_accuracy", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // ADS精度倍率（高い値 = 高精度 = 低inaccuracy）
+    public static final RegistryObject<Attribute> ADS_ACCURACY = ATTRIBUTES.register("ads_accuracy",
+            () -> new RangedAttribute("attribute.tacz_attributes.ads_accuracy", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // 腰撃ちダメージ倍率
+    public static final RegistryObject<Attribute> HIP_FIRE_DAMAGE = ATTRIBUTES.register("hip_fire_damage",
+            () -> new RangedAttribute("attribute.tacz_attributes.hip_fire_damage", 1.0, 0.0, 1024.0).setSyncable(true));
+
+    // ADSダメージ倍率
+    public static final RegistryObject<Attribute> ADS_DAMAGE = ATTRIBUTES.register("ads_damage",
+            () -> new RangedAttribute("attribute.tacz_attributes.ads_damage", 1.0, 0.0, 1024.0).setSyncable(true));
+
+    // フルオートダメージ倍率
+    public static final RegistryObject<Attribute> AUTO_DAMAGE = ATTRIBUTES.register("auto_damage",
+            () -> new RangedAttribute("attribute.tacz_attributes.auto_damage", 1.0, 0.0, 1024.0).setSyncable(true));
+
+    // セミオートダメージ倍率
+    public static final RegistryObject<Attribute> SEMI_DAMAGE = ATTRIBUTES.register("semi_damage",
+            () -> new RangedAttribute("attribute.tacz_attributes.semi_damage", 1.0, 0.0, 1024.0).setSyncable(true));
+
+    // バーストダメージ倍率
+    public static final RegistryObject<Attribute> BURST_DAMAGE = ATTRIBUTES.register("burst_damage",
+            () -> new RangedAttribute("attribute.tacz_attributes.burst_damage", 1.0, 0.0, 1024.0).setSyncable(true));
+
+    // フルオート精度倍率
+    public static final RegistryObject<Attribute> AUTO_ACCURACY = ATTRIBUTES.register("auto_accuracy",
+            () -> new RangedAttribute("attribute.tacz_attributes.auto_accuracy", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // セミオート精度倍率
+    public static final RegistryObject<Attribute> SEMI_ACCURACY = ATTRIBUTES.register("semi_accuracy",
+            () -> new RangedAttribute("attribute.tacz_attributes.semi_accuracy", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // バースト精度倍率
+    public static final RegistryObject<Attribute> BURST_ACCURACY = ATTRIBUTES.register("burst_accuracy",
+            () -> new RangedAttribute("attribute.tacz_attributes.burst_accuracy", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // 全般反動倍率（高い値 = 高反動）
+    public static final RegistryObject<Attribute> RECOIL = ATTRIBUTES.register("recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // 縦反動倍率
+    public static final RegistryObject<Attribute> VERTICAL_RECOIL = ATTRIBUTES.register("vertical_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.vertical_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // 横反動倍率
+    public static final RegistryObject<Attribute> HORIZONTAL_RECOIL = ATTRIBUTES.register("horizontal_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.horizontal_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // ADS反動倍率
+    public static final RegistryObject<Attribute> ADS_RECOIL = ATTRIBUTES.register("ads_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.ads_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // ADS縦反動倍率
+    public static final RegistryObject<Attribute> ADS_VERTICAL_RECOIL = ATTRIBUTES.register("ads_vertical_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.ads_vertical_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // ADS横反動倍率
+    public static final RegistryObject<Attribute> ADS_HORIZONTAL_RECOIL = ATTRIBUTES.register("ads_horizontal_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.ads_horizontal_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // 腰撃ち反動倍率
+    public static final RegistryObject<Attribute> HIP_FIRE_RECOIL = ATTRIBUTES.register("hip_fire_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.hip_fire_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // 腰撃ち縦反動倍率
+    public static final RegistryObject<Attribute> HIP_FIRE_VERTICAL_RECOIL = ATTRIBUTES.register("hip_fire_vertical_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.hip_fire_vertical_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // 腰撃ち横反動倍率
+    public static final RegistryObject<Attribute> HIP_FIRE_HORIZONTAL_RECOIL = ATTRIBUTES.register("hip_fire_horizontal_recoil",
+            () -> new RangedAttribute("attribute.tacz_attributes.hip_fire_horizontal_recoil", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // 銃装備時移動速度倍率（1.0 = 変更なし、0.5 = 50%速度、2.0 = 200%速度）
+    public static final RegistryObject<Attribute> GUN_MOVEMENT_SPEED = ATTRIBUTES.register("gun_movement_speed",
+            () -> new RangedAttribute("attribute.tacz_attributes.gun_movement_speed", 1.0, 0.01, 10.0).setSyncable(true));
+
+    // ヘッドショット倍率（1.0 = 変更なし、2.0 = ヘッドショットダメージ2倍）
+    public static final RegistryObject<Attribute> HEADSHOT_MULTIPLIER = ATTRIBUTES.register("headshot_multiplier",
+            () -> new RangedAttribute("attribute.tacz_attributes.headshot_multiplier", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // ノックバック倍率（1.0 = 変更なし、0.0 = ノックバックなし、2.0 = 2倍）
+    public static final RegistryObject<Attribute> KNOCKBACK_MULTIPLIER = ATTRIBUTES.register("knockback_multiplier",
+            () -> new RangedAttribute("attribute.tacz_attributes.knockback_multiplier", 1.0, 0.0, 100.0).setSyncable(true));
+
+    // ノックバック基本値（0.0 = 追加なし、0.4 = バニラ攻撃相当のノックバック追加）
+    public static final RegistryObject<Attribute> KNOCKBACK_BASE = ATTRIBUTES.register("knockback_base",
+            () -> new RangedAttribute("attribute.tacz_attributes.knockback_base", 0.0, 0.0, 100.0).setSyncable(true));
+
+    // 貫通数倍率（1.0 = 変更なし、2.0 = 貫通数2倍）
+    public static final RegistryObject<Attribute> PIERCE_MULTIPLIER = ATTRIBUTES.register("pierce_multiplier",
+            () -> new RangedAttribute("attribute.tacz_attributes.pierce_multiplier", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // 発射レート(RPM)倍率（1.0 = 変更なし、2.0 = 2倍速射）
+    public static final RegistryObject<Attribute> RPM_MULTIPLIER = ATTRIBUTES.register("rpm_multiplier",
+            () -> new RangedAttribute("attribute.tacz_attributes.rpm_multiplier", 1.0, 0.01, 10.0).setSyncable(true));
+
+    // ADS移行速度倍率（1.0 = 変更なし、2.0 = ADS2倍速）
+    public static final RegistryObject<Attribute> ADS_SPEED = ATTRIBUTES.register("ads_speed",
+            () -> new RangedAttribute("attribute.tacz_attributes.ads_speed", 1.0, 0.01, 10.0).setSyncable(true));
+
+    // セミオート弾数倍率（1.0 = 変更なし、2.0 = 弾数2倍）
+    public static final RegistryObject<Attribute> SEMI_BULLET_AMOUNT = ATTRIBUTES.register("semi_bullet_amount",
+            () -> new RangedAttribute("attribute.tacz_attributes.semi_bullet_amount", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // フルオート弾数倍率（1.0 = 変更なし、2.0 = 弾数2倍）
+    public static final RegistryObject<Attribute> AUTO_BULLET_AMOUNT = ATTRIBUTES.register("auto_bullet_amount",
+            () -> new RangedAttribute("attribute.tacz_attributes.auto_bullet_amount", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // バースト弾数倍率（1.0 = 変更なし、2.0 = バースト数2倍）
+    public static final RegistryObject<Attribute> BURST_BULLET_AMOUNT = ATTRIBUTES.register("burst_bullet_amount",
+            () -> new RangedAttribute("attribute.tacz_attributes.burst_bullet_amount", 1.0, 0.01, 100.0).setSyncable(true));
+
+    // 武器切替速度倍率（1.0 = 変更なし、2.0 = 取り出し/しまい2倍速）
+    public static final RegistryObject<Attribute> DRAW_SPEED = ATTRIBUTES.register("draw_speed",
+            () -> new RangedAttribute("attribute.tacz_attributes.draw_speed", 1.0, 0.01, 10.0).setSyncable(true));
+
     // 銃種別属性の一括登録
     static {
         GunType.registerAll(ATTRIBUTES);

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/CustomAttributes.java
@@ -187,6 +187,10 @@ public class CustomAttributes {
     public static final RegistryObject<Attribute> DRAW_SPEED = ATTRIBUTES.register("draw_speed",
             () -> new RangedAttribute("attribute.tacz_attributes.draw_speed", 1.0, 0.01, 10.0).setSyncable(true));
 
+    // バースト速度倍率（1.0 = 変更なし、2.0 = バースト間隔半分）
+    public static final RegistryObject<Attribute> BURST_SPEED = ATTRIBUTES.register("burst_speed",
+            () -> new RangedAttribute("attribute.tacz_attributes.burst_speed", 1.0, 0.01, 10.0).setSyncable(true));
+
     // 銃種別属性の一括登録
     static {
         GunType.registerAll(ATTRIBUTES);

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
@@ -24,6 +24,36 @@ public class EntityAttributeSetup {
             event.add(EntityType.PLAYER, CustomAttributes.BONUS_AMMO_CHANCE.get());
             event.add(EntityType.PLAYER, CustomAttributes.BONUS_AMMO_AMOUNT.get());
             event.add(EntityType.PLAYER, CustomAttributes.BONUS_AMMO_PERCENT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HIP_FIRE_ACCURACY.get());
+            event.add(EntityType.PLAYER, CustomAttributes.ADS_ACCURACY.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HIP_FIRE_DAMAGE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.ADS_DAMAGE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AUTO_DAMAGE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.SEMI_DAMAGE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BURST_DAMAGE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AUTO_ACCURACY.get());
+            event.add(EntityType.PLAYER, CustomAttributes.SEMI_ACCURACY.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BURST_ACCURACY.get());
+            event.add(EntityType.PLAYER, CustomAttributes.RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.VERTICAL_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HORIZONTAL_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.ADS_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.ADS_VERTICAL_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.ADS_HORIZONTAL_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HIP_FIRE_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HIP_FIRE_VERTICAL_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HIP_FIRE_HORIZONTAL_RECOIL.get());
+            event.add(EntityType.PLAYER, CustomAttributes.GUN_MOVEMENT_SPEED.get());
+            event.add(EntityType.PLAYER, CustomAttributes.HEADSHOT_MULTIPLIER.get());
+            event.add(EntityType.PLAYER, CustomAttributes.KNOCKBACK_MULTIPLIER.get());
+            event.add(EntityType.PLAYER, CustomAttributes.KNOCKBACK_BASE.get());
+            event.add(EntityType.PLAYER, CustomAttributes.PIERCE_MULTIPLIER.get());
+            event.add(EntityType.PLAYER, CustomAttributes.RPM_MULTIPLIER.get());
+            event.add(EntityType.PLAYER, CustomAttributes.ADS_SPEED.get());
+            event.add(EntityType.PLAYER, CustomAttributes.SEMI_BULLET_AMOUNT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.AUTO_BULLET_AMOUNT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BURST_BULLET_AMOUNT.get());
+            event.add(EntityType.PLAYER, CustomAttributes.DRAW_SPEED.get());
 
             // 銃種別属性
             for (GunType gunType : GunType.values()) {
@@ -39,6 +69,36 @@ public class EntityAttributeSetup {
                 event.add(EntityType.PLAYER, gunType.getBonusAmmoChanceAttribute().get());
                 event.add(EntityType.PLAYER, gunType.getBonusAmmoAmountAttribute().get());
                 event.add(EntityType.PLAYER, gunType.getBonusAmmoPercentAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHipFireAccuracyAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAdsAccuracyAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHipFireDamageAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAdsDamageAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAutoDamageAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getSemiDamageAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBurstDamageAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAutoAccuracyAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getSemiAccuracyAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBurstAccuracyAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getVerticalRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHorizontalRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAdsRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAdsVerticalRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAdsHorizontalRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHipFireRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHipFireVerticalRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHipFireHorizontalRecoilAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getGunMovementSpeedAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getHeadshotMultiplierAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getKnockbackMultiplierAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getKnockbackBaseAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getPierceMultiplierAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getRpmMultiplierAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAdsSpeedAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getSemiBulletAmountAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getAutoBulletAmountAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBurstBulletAmountAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getDrawSpeedAttribute().get());
             }
         }
     }

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/EntityAttributeSetup.java
@@ -54,6 +54,7 @@ public class EntityAttributeSetup {
             event.add(EntityType.PLAYER, CustomAttributes.AUTO_BULLET_AMOUNT.get());
             event.add(EntityType.PLAYER, CustomAttributes.BURST_BULLET_AMOUNT.get());
             event.add(EntityType.PLAYER, CustomAttributes.DRAW_SPEED.get());
+            event.add(EntityType.PLAYER, CustomAttributes.BURST_SPEED.get());
 
             // 銃種別属性
             for (GunType gunType : GunType.values()) {
@@ -99,6 +100,7 @@ public class EntityAttributeSetup {
                 event.add(EntityType.PLAYER, gunType.getAutoBulletAmountAttribute().get());
                 event.add(EntityType.PLAYER, gunType.getBurstBulletAmountAttribute().get());
                 event.add(EntityType.PLAYER, gunType.getDrawSpeedAttribute().get());
+                event.add(EntityType.PLAYER, gunType.getBurstSpeedAttribute().get());
             }
         }
     }

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
@@ -66,6 +66,7 @@ public enum GunType {
     private RegistryObject<Attribute> autoBulletAmountAttribute;
     private RegistryObject<Attribute> burstBulletAmountAttribute;
     private RegistryObject<Attribute> drawSpeedAttribute;
+    private RegistryObject<Attribute> burstSpeedAttribute;
 
     private static final Map<String, GunType> BY_TYPE_ID = new HashMap<>();
 
@@ -251,6 +252,10 @@ public enum GunType {
         return drawSpeedAttribute;
     }
 
+    public RegistryObject<Attribute> getBurstSpeedAttribute() {
+        return burstSpeedAttribute;
+    }
+
     /**
      * TaCZ の銃種文字列（CommonGunIndex.getType() の戻り値）から GunType を取得する。
      * 不明な銃種の場合は null を返す。
@@ -310,6 +315,7 @@ public enum GunType {
             type.autoBulletAmountAttribute = registerBulletAmount(registry, id + "_auto_bullet_amount");
             type.burstBulletAmountAttribute = registerBulletAmount(registry, id + "_burst_bullet_amount");
             type.drawSpeedAttribute = registerSpeedMultiplier(registry, id + "_draw_speed");
+            type.burstSpeedAttribute = registerSpeedMultiplier(registry, id + "_burst_speed");
         }
     }
 

--- a/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/attribute/GunType.java
@@ -11,9 +11,8 @@ import java.util.Map;
 
 /**
  * TaCZ の銃種分類に対応する enum。
- * 各銃種ごとにダメージ倍率、リロード速度倍率、コッキング速度倍率、
- * マガジン容量倍率、弾薬非消費確率、キル時弾薬回復、リロード時弾薬非消費、
- * リロード時追加弾薬の属性を保持する。
+ * 各銃種ごとにダメージ倍率、リロード速度倍率、コッキング速度倍率、マガジン容量倍率、
+ * 弾薬非消費確率、キル時弾薬回復、精度倍率、反動倍率、射撃モード別倍率等の属性を保持する。
  */
 public enum GunType {
     PISTOL("pistol"),
@@ -37,6 +36,36 @@ public enum GunType {
     private RegistryObject<Attribute> bonusAmmoChanceAttribute;
     private RegistryObject<Attribute> bonusAmmoAmountAttribute;
     private RegistryObject<Attribute> bonusAmmoPercentAttribute;
+    private RegistryObject<Attribute> hipFireAccuracyAttribute;
+    private RegistryObject<Attribute> adsAccuracyAttribute;
+    private RegistryObject<Attribute> hipFireDamageAttribute;
+    private RegistryObject<Attribute> adsDamageAttribute;
+    private RegistryObject<Attribute> autoDamageAttribute;
+    private RegistryObject<Attribute> semiDamageAttribute;
+    private RegistryObject<Attribute> burstDamageAttribute;
+    private RegistryObject<Attribute> autoAccuracyAttribute;
+    private RegistryObject<Attribute> semiAccuracyAttribute;
+    private RegistryObject<Attribute> burstAccuracyAttribute;
+    private RegistryObject<Attribute> recoilAttribute;
+    private RegistryObject<Attribute> verticalRecoilAttribute;
+    private RegistryObject<Attribute> horizontalRecoilAttribute;
+    private RegistryObject<Attribute> adsRecoilAttribute;
+    private RegistryObject<Attribute> adsVerticalRecoilAttribute;
+    private RegistryObject<Attribute> adsHorizontalRecoilAttribute;
+    private RegistryObject<Attribute> hipFireRecoilAttribute;
+    private RegistryObject<Attribute> hipFireVerticalRecoilAttribute;
+    private RegistryObject<Attribute> hipFireHorizontalRecoilAttribute;
+    private RegistryObject<Attribute> gunMovementSpeedAttribute;
+    private RegistryObject<Attribute> headshotMultiplierAttribute;
+    private RegistryObject<Attribute> knockbackMultiplierAttribute;
+    private RegistryObject<Attribute> knockbackBaseAttribute;
+    private RegistryObject<Attribute> pierceMultiplierAttribute;
+    private RegistryObject<Attribute> rpmMultiplierAttribute;
+    private RegistryObject<Attribute> adsSpeedAttribute;
+    private RegistryObject<Attribute> semiBulletAmountAttribute;
+    private RegistryObject<Attribute> autoBulletAmountAttribute;
+    private RegistryObject<Attribute> burstBulletAmountAttribute;
+    private RegistryObject<Attribute> drawSpeedAttribute;
 
     private static final Map<String, GunType> BY_TYPE_ID = new HashMap<>();
 
@@ -102,6 +131,126 @@ public enum GunType {
         return bonusAmmoPercentAttribute;
     }
 
+    public RegistryObject<Attribute> getHipFireAccuracyAttribute() {
+        return hipFireAccuracyAttribute;
+    }
+
+    public RegistryObject<Attribute> getAdsAccuracyAttribute() {
+        return adsAccuracyAttribute;
+    }
+
+    public RegistryObject<Attribute> getHipFireDamageAttribute() {
+        return hipFireDamageAttribute;
+    }
+
+    public RegistryObject<Attribute> getAdsDamageAttribute() {
+        return adsDamageAttribute;
+    }
+
+    public RegistryObject<Attribute> getAutoDamageAttribute() {
+        return autoDamageAttribute;
+    }
+
+    public RegistryObject<Attribute> getSemiDamageAttribute() {
+        return semiDamageAttribute;
+    }
+
+    public RegistryObject<Attribute> getBurstDamageAttribute() {
+        return burstDamageAttribute;
+    }
+
+    public RegistryObject<Attribute> getAutoAccuracyAttribute() {
+        return autoAccuracyAttribute;
+    }
+
+    public RegistryObject<Attribute> getSemiAccuracyAttribute() {
+        return semiAccuracyAttribute;
+    }
+
+    public RegistryObject<Attribute> getBurstAccuracyAttribute() {
+        return burstAccuracyAttribute;
+    }
+
+    public RegistryObject<Attribute> getRecoilAttribute() {
+        return recoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getVerticalRecoilAttribute() {
+        return verticalRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getHorizontalRecoilAttribute() {
+        return horizontalRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getAdsRecoilAttribute() {
+        return adsRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getAdsVerticalRecoilAttribute() {
+        return adsVerticalRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getAdsHorizontalRecoilAttribute() {
+        return adsHorizontalRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getHipFireRecoilAttribute() {
+        return hipFireRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getHipFireVerticalRecoilAttribute() {
+        return hipFireVerticalRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getHipFireHorizontalRecoilAttribute() {
+        return hipFireHorizontalRecoilAttribute;
+    }
+
+    public RegistryObject<Attribute> getGunMovementSpeedAttribute() {
+        return gunMovementSpeedAttribute;
+    }
+
+    public RegistryObject<Attribute> getHeadshotMultiplierAttribute() {
+        return headshotMultiplierAttribute;
+    }
+
+    public RegistryObject<Attribute> getKnockbackMultiplierAttribute() {
+        return knockbackMultiplierAttribute;
+    }
+
+    public RegistryObject<Attribute> getKnockbackBaseAttribute() {
+        return knockbackBaseAttribute;
+    }
+
+    public RegistryObject<Attribute> getPierceMultiplierAttribute() {
+        return pierceMultiplierAttribute;
+    }
+
+    public RegistryObject<Attribute> getRpmMultiplierAttribute() {
+        return rpmMultiplierAttribute;
+    }
+
+    public RegistryObject<Attribute> getAdsSpeedAttribute() {
+        return adsSpeedAttribute;
+    }
+
+    public RegistryObject<Attribute> getSemiBulletAmountAttribute() {
+        return semiBulletAmountAttribute;
+    }
+
+    public RegistryObject<Attribute> getAutoBulletAmountAttribute() {
+        return autoBulletAmountAttribute;
+    }
+
+    public RegistryObject<Attribute> getBurstBulletAmountAttribute() {
+        return burstBulletAmountAttribute;
+    }
+
+    public RegistryObject<Attribute> getDrawSpeedAttribute() {
+        return drawSpeedAttribute;
+    }
+
     /**
      * TaCZ の銃種文字列（CommonGunIndex.getType() の戻り値）から GunType を取得する。
      * 不明な銃種の場合は null を返す。
@@ -117,90 +266,100 @@ public enum GunType {
      */
     public static void registerAll(DeferredRegister<Attribute> registry) {
         for (GunType type : values()) {
-            type.damageAttribute = registry.register(
-                    type.typeId + "_damage",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_damage",
-                            1.0, 0.0, 1024.0
-                    ).setSyncable(true)
-            );
-            type.reloadSpeedAttribute = registry.register(
-                    type.typeId + "_reload_speed",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_reload_speed",
-                            1.0, 0.1, 20.0
-                    ).setSyncable(true)
-            );
-            type.boltActionSpeedAttribute = registry.register(
-                    type.typeId + "_bolt_action_speed",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_bolt_action_speed",
-                            1.0, 0.1, 20.0
-                    ).setSyncable(true)
-            );
-            type.magazineCapacityAttribute = registry.register(
-                    type.typeId + "_magazine_capacity",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_magazine_capacity",
-                            1.0, 0.1, 100.0
-                    ).setSyncable(true)
-            );
-            type.ammoSaveChanceAttribute = registry.register(
-                    type.typeId + "_ammo_save_chance",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_ammo_save_chance",
-                            0.0, 0.0, 1.0
-                    ).setSyncable(true)
-            );
-            type.ammoRecoveryChanceAttribute = registry.register(
-                    type.typeId + "_ammo_recovery_chance",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_ammo_recovery_chance",
-                            0.0, 0.0, 1.0
-                    ).setSyncable(true)
-            );
-            type.ammoRecoveryAmountAttribute = registry.register(
-                    type.typeId + "_ammo_recovery_amount",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_ammo_recovery_amount",
-                            0.0, 0.0, 100.0
-                    ).setSyncable(true)
-            );
-            type.ammoRecoveryPercentAttribute = registry.register(
-                    type.typeId + "_ammo_recovery_percent",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_ammo_recovery_percent",
-                            0.0, 0.0, 1.0
-                    ).setSyncable(true)
-            );
-            type.reloadAmmoSaveChanceAttribute = registry.register(
-                    type.typeId + "_reload_ammo_save_chance",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_reload_ammo_save_chance",
-                            0.0, 0.0, 1.0
-                    ).setSyncable(true)
-            );
-            type.bonusAmmoChanceAttribute = registry.register(
-                    type.typeId + "_bonus_ammo_chance",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_bonus_ammo_chance",
-                            0.0, 0.0, 1.0
-                    ).setSyncable(true)
-            );
-            type.bonusAmmoAmountAttribute = registry.register(
-                    type.typeId + "_bonus_ammo_amount",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_bonus_ammo_amount",
-                            0.0, 0.0, 100.0
-                    ).setSyncable(true)
-            );
-            type.bonusAmmoPercentAttribute = registry.register(
-                    type.typeId + "_bonus_ammo_percent",
-                    () -> new RangedAttribute(
-                            "attribute.tacz_attributes." + type.typeId + "_bonus_ammo_percent",
-                            0.0, 0.0, 1.0
-                    ).setSyncable(true)
-            );
+            String id = type.typeId;
+
+            type.damageAttribute = registerDamage(registry, id + "_damage");
+            type.reloadSpeedAttribute = registerReloadSpeed(registry, id + "_reload_speed");
+            type.boltActionSpeedAttribute = registerReloadSpeed(registry, id + "_bolt_action_speed");
+            type.magazineCapacityAttribute = registerBulletAmount(registry, id + "_magazine_capacity");
+            type.ammoSaveChanceAttribute = registerChance(registry, id + "_ammo_save_chance");
+            type.ammoRecoveryChanceAttribute = registerChance(registry, id + "_ammo_recovery_chance");
+            type.ammoRecoveryAmountAttribute = registerKnockbackBase(registry, id + "_ammo_recovery_amount");
+            type.ammoRecoveryPercentAttribute = registerChance(registry, id + "_ammo_recovery_percent");
+            type.reloadAmmoSaveChanceAttribute = registerChance(registry, id + "_reload_ammo_save_chance");
+            type.bonusAmmoChanceAttribute = registerChance(registry, id + "_bonus_ammo_chance");
+            type.bonusAmmoAmountAttribute = registerKnockbackBase(registry, id + "_bonus_ammo_amount");
+            type.bonusAmmoPercentAttribute = registerChance(registry, id + "_bonus_ammo_percent");
+            type.hipFireAccuracyAttribute = registerAccuracy(registry, id + "_hip_fire_accuracy");
+            type.adsAccuracyAttribute = registerAccuracy(registry, id + "_ads_accuracy");
+            type.hipFireDamageAttribute = registerDamage(registry, id + "_hip_fire_damage");
+            type.adsDamageAttribute = registerDamage(registry, id + "_ads_damage");
+            type.autoDamageAttribute = registerDamage(registry, id + "_auto_damage");
+            type.semiDamageAttribute = registerDamage(registry, id + "_semi_damage");
+            type.burstDamageAttribute = registerDamage(registry, id + "_burst_damage");
+            type.autoAccuracyAttribute = registerAccuracy(registry, id + "_auto_accuracy");
+            type.semiAccuracyAttribute = registerAccuracy(registry, id + "_semi_accuracy");
+            type.burstAccuracyAttribute = registerAccuracy(registry, id + "_burst_accuracy");
+            type.recoilAttribute = registerRecoil(registry, id + "_recoil");
+            type.verticalRecoilAttribute = registerRecoil(registry, id + "_vertical_recoil");
+            type.horizontalRecoilAttribute = registerRecoil(registry, id + "_horizontal_recoil");
+            type.adsRecoilAttribute = registerRecoil(registry, id + "_ads_recoil");
+            type.adsVerticalRecoilAttribute = registerRecoil(registry, id + "_ads_vertical_recoil");
+            type.adsHorizontalRecoilAttribute = registerRecoil(registry, id + "_ads_horizontal_recoil");
+            type.hipFireRecoilAttribute = registerRecoil(registry, id + "_hip_fire_recoil");
+            type.hipFireVerticalRecoilAttribute = registerRecoil(registry, id + "_hip_fire_vertical_recoil");
+            type.hipFireHorizontalRecoilAttribute = registerRecoil(registry, id + "_hip_fire_horizontal_recoil");
+            type.gunMovementSpeedAttribute = registerSpeedMultiplier(registry, id + "_gun_movement_speed");
+            type.headshotMultiplierAttribute = registerGenericMultiplier(registry, id + "_headshot_multiplier");
+            type.knockbackMultiplierAttribute = registerGenericMultiplier(registry, id + "_knockback_multiplier");
+            type.knockbackBaseAttribute = registerKnockbackBase(registry, id + "_knockback_base");
+            type.pierceMultiplierAttribute = registerPierceMultiplier(registry, id + "_pierce_multiplier");
+            type.rpmMultiplierAttribute = registerSpeedMultiplier(registry, id + "_rpm_multiplier");
+            type.adsSpeedAttribute = registerSpeedMultiplier(registry, id + "_ads_speed");
+            type.semiBulletAmountAttribute = registerBulletAmount(registry, id + "_semi_bullet_amount");
+            type.autoBulletAmountAttribute = registerBulletAmount(registry, id + "_auto_bullet_amount");
+            type.burstBulletAmountAttribute = registerBulletAmount(registry, id + "_burst_bullet_amount");
+            type.drawSpeedAttribute = registerSpeedMultiplier(registry, id + "_draw_speed");
         }
+    }
+
+    private static RegistryObject<Attribute> registerDamage(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.0, 1024.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerAccuracy(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.01, 100.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerReloadSpeed(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.1, 20.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerRecoil(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.0, 100.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerGenericMultiplier(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.0, 100.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerPierceMultiplier(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.01, 100.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerSpeedMultiplier(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.01, 10.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerBulletAmount(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 1.0, 0.01, 100.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerKnockbackBase(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 0.0, 0.0, 100.0).setSyncable(true));
+    }
+
+    private static RegistryObject<Attribute> registerChance(DeferredRegister<Attribute> registry, String name) {
+        return registry.register(name,
+                () -> new RangedAttribute("attribute.tacz_attributes." + name, 0.0, 0.0, 1.0).setSyncable(true));
     }
 }

--- a/src/main/java/com/github/leopoko/tacz_attributes/client/DrawAnimationSpeedHandler.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/client/DrawAnimationSpeedHandler.java
@@ -1,0 +1,150 @@
+package com.github.leopoko.tacz_attributes.client;
+
+import com.github.leopoko.tacz_attributes.Tacz_attributes;
+import com.github.leopoko.tacz_attributes.api.ISpeedModifiable;
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.client.animation.AnimationController;
+import com.tacz.guns.api.client.animation.DiscreteTrackArray;
+import com.tacz.guns.api.client.animation.ObjectAnimationRunner;
+import com.tacz.guns.api.client.animation.statemachine.AnimationStateMachine;
+import com.tacz.guns.api.entity.IGunOperator;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.client.resource.GunDisplayInstance;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * クライアント側でdrawアニメーションの速度をdraw_speed属性に追従させるイベントハンドラ。
+ * <p>
+ * Luaステートマシンでは:
+ * - put_away: context:getPutAwayTime() でアニメーション速度が決まる（GunItemRendererWrapperMixinで対応済み）
+ * - draw: アニメーションは固定速度で再生されるため、ObjectAnimationRunner の speedMultiplier で加速する
+ * <p>
+ * 毎クライアントtickで以下を行う:
+ * 1. getSynDrawCoolDown() でdraw/put-away状態を検出
+ * 2. draw状態中であればMAIN_TRACKのアニメーションランナーに速度倍率を設定
+ * 3. draw終了時に速度倍率をリセット
+ */
+@Mod.EventBusSubscriber(modid = Tacz_attributes.MODID, value = Dist.CLIENT)
+public class DrawAnimationSpeedHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * デフォルトステートマシンでのMAIN_TRACKの位置。
+     * STATIC_TRACK_LINE = 0, MAIN_TRACK = trackIndex 4
+     * (BASE=0, BOLT_CAUGHT=1, SAFETY=2, ADS=3, MAIN=4)
+     */
+    private static final int STATIC_TRACK_LINE = 0;
+    private static final int MAIN_TRACK_INDEX = 4;
+
+    private static boolean wasDrawing = false;
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.START) return;
+
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return;
+
+        long drawCoolDown = IGunOperator.fromLivingEntity(player).getSynDrawCoolDown();
+        boolean isDrawing = drawCoolDown > 0;
+
+        if (isDrawing) {
+            double speed = getDrawSpeedModifier(player);
+            if (speed != 1.0) {
+                applySpeedToMainTrack(player, (float) speed);
+            }
+            wasDrawing = true;
+        } else if (wasDrawing) {
+            // draw終了時に速度倍率をリセット
+            applySpeedToMainTrack(player, 1.0f);
+            wasDrawing = false;
+        }
+    }
+
+    private static double getDrawSpeedModifier(LocalPlayer player) {
+        double globalSpeed = getAttributeValue(player, CustomAttributes.DRAW_SPEED.get());
+
+        // 銃種は現在のメインハンド（新しい武器）で判定
+        ItemStack mainHand = player.getMainHandItem();
+        GunType gunType = GunTypeResolver.resolveFromItem(mainHand);
+        double typeSpeed = 1.0;
+        if (gunType != null) {
+            typeSpeed = getAttributeValue(player, gunType.getDrawSpeedAttribute().get());
+        }
+
+        return globalSpeed * typeSpeed;
+    }
+
+    /**
+     * MAIN_TRACKのアニメーションランナーに速度倍率を設定する。
+     * ランナーが遷移中の場合、遷移先のランナーにも設定する。
+     */
+    private static void applySpeedToMainTrack(LocalPlayer player, float speed) {
+        ItemStack mainHand = player.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(mainHand);
+        if (iGun == null) return;
+
+        GunDisplayInstance display = TimelessAPI.getGunDisplay(mainHand).orElse(null);
+        if (display == null) return;
+
+        AnimationStateMachine<?> stateMachine = display.getAnimationStateMachine();
+        if (stateMachine == null || !stateMachine.isInitialized()) return;
+
+        AnimationController controller = stateMachine.getAnimationController();
+        if (controller == null) return;
+
+        var context = stateMachine.getContext();
+        if (context == null) return;
+
+        DiscreteTrackArray trackArray = context.getTrackArray();
+        if (trackArray.getTrackLineSize() <= STATIC_TRACK_LINE) return;
+
+        List<Integer> staticTracks = trackArray.getByIndex(STATIC_TRACK_LINE);
+        if (staticTracks.size() <= MAIN_TRACK_INDEX) return;
+
+        int mainTrackPointer = staticTracks.get(MAIN_TRACK_INDEX);
+        ObjectAnimationRunner runner = controller.getAnimation(mainTrackPointer);
+        if (runner == null) return;
+
+        // ランナーに速度倍率を設定
+        setSpeedOnRunner(runner, speed);
+
+        // 遷移先のランナーにも設定
+        ObjectAnimationRunner transitionTo = runner.getTransitionTo();
+        if (transitionTo != null) {
+            setSpeedOnRunner(transitionTo, speed);
+        }
+    }
+
+    private static void setSpeedOnRunner(ObjectAnimationRunner runner, float speed) {
+        if (runner instanceof ISpeedModifiable modifiable) {
+            modifiable.tacz_attributes$setSpeedMultiplier(speed);
+            if (!FMLEnvironment.production && speed != 1.0f) {
+                LOGGER.debug("[TaCZ Attributes] Drawアニメーション速度倍率設定: {}", speed);
+            }
+        }
+    }
+
+    private static double getAttributeValue(LocalPlayer player, Attribute attribute) {
+        if (player.getAttributes().hasAttribute(attribute)) {
+            return player.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/BulletAmountMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/BulletAmountMixin.java
@@ -1,0 +1,173 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.api.item.gun.FireMode;
+import com.tacz.guns.item.ModernKineticGunScriptAPI;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * ModernKineticGunScriptAPI.shootOnce() に対するMixin。
+ * <p>
+ * - セミオート/フルオート弾数倍率: bulletAmount (int ordinal 1) を変更
+ * - バースト弾数倍率: cycles (int ordinal 2) を変更
+ * <p>
+ * 計算式:
+ * セミ/フルオート: 最終bulletAmount = bulletAmount × (全体倍率 × 銃種別倍率)
+ * バースト: 最終cycles = cycles × (全体倍率 × 銃種別倍率)
+ */
+@Mixin(ModernKineticGunScriptAPI.class)
+public class BulletAmountMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    private LivingEntity shooter;
+
+    @Shadow(remap = false)
+    private ItemStack itemStack;
+
+    /**
+     * shootOnce() 内の bulletAmount (int ordinal 1) を変更し、
+     * セミオート/フルオート時の弾数倍率を適用する。
+     */
+    @ModifyVariable(
+            method = "shootOnce",
+            at = @At("STORE"),
+            ordinal = 1,
+            remap = false
+    )
+    private int tacz_attributes$modifyBulletAmount(int bulletAmount) {
+        if (this.shooter == null) return bulletAmount;
+
+        IGun iGun = IGun.getIGunOrNull(this.itemStack);
+        if (iGun == null) return bulletAmount;
+        FireMode mode = iGun.getFireMode(this.itemStack);
+
+        Attribute globalAttr;
+        if (mode == FireMode.SEMI) {
+            globalAttr = CustomAttributes.SEMI_BULLET_AMOUNT.get();
+        } else if (mode == FireMode.AUTO) {
+            globalAttr = CustomAttributes.AUTO_BULLET_AMOUNT.get();
+        } else {
+            return bulletAmount; // BURST時はcyclesで変更するためここでは変更しない
+        }
+
+        GunType gunType = GunTypeResolver.resolveFromItem(this.itemStack);
+        double globalMult = tacz_attributes$getAttributeValue(this.shooter, globalAttr);
+        double typeMult = 1.0;
+        if (gunType != null) {
+            Attribute typeAttr = (mode == FireMode.SEMI)
+                    ? gunType.getSemiBulletAmountAttribute().get()
+                    : gunType.getAutoBulletAmountAttribute().get();
+            typeMult = tacz_attributes$getAttributeValue(this.shooter, typeAttr);
+        }
+        double combined = globalMult * typeMult;
+        if (combined == 1.0) return bulletAmount;
+
+        int modified = Math.max(1, (int) (bulletAmount * combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] {}弾数倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
+                    mode == FireMode.SEMI ? "セミ" : "フルオート",
+                    bulletAmount, modified, globalMult,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeMult);
+        }
+
+        return modified;
+    }
+
+    /**
+     * shootOnce() 内の cycles (int ordinal 2) を変更し、
+     * バースト時の弾数（バーストカウント）倍率を適用する。
+     */
+    @ModifyVariable(
+            method = "shootOnce",
+            at = @At("STORE"),
+            ordinal = 2,
+            remap = false
+    )
+    private int tacz_attributes$modifyCycles(int cycles) {
+        if (this.shooter == null || cycles <= 1) return cycles; // 非バースト(cycles=1)は変更しない
+
+        GunType gunType = GunTypeResolver.resolveFromItem(this.itemStack);
+        double globalMult = tacz_attributes$getAttributeValue(this.shooter, CustomAttributes.BURST_BULLET_AMOUNT.get());
+        double typeMult = 1.0;
+        if (gunType != null) {
+            typeMult = tacz_attributes$getAttributeValue(this.shooter, gunType.getBurstBulletAmountAttribute().get());
+        }
+        double combined = globalMult * typeMult;
+        if (combined == 1.0) return cycles;
+
+        int modified = Math.max(1, (int) (cycles * combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] バースト弾数倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
+                    cycles, modified, globalMult,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeMult);
+        }
+
+        return modified;
+    }
+
+    /**
+     * shootOnce() 内の burstShootInterval (long ordinal 0) を変更し、
+     * バースト間隔速度倍率を適用する。
+     * <p>
+     * 計算式: 最終interval = interval / (全体倍率 × 銃種別倍率)
+     * burst_speed 2.0 → 間隔半分 → より速いバースト
+     */
+    @ModifyVariable(
+            method = "shootOnce",
+            at = @At("STORE"),
+            ordinal = 0,
+            remap = false
+    )
+    private long tacz_attributes$modifyBurstInterval(long interval) {
+        if (this.shooter == null || interval <= 1) return interval;
+
+        IGun iGun = IGun.getIGunOrNull(this.itemStack);
+        if (iGun == null) return interval;
+        FireMode mode = iGun.getFireMode(this.itemStack);
+        if (mode != FireMode.BURST) return interval;
+
+        GunType gunType = GunTypeResolver.resolveFromItem(this.itemStack);
+        double globalMult = tacz_attributes$getAttributeValue(this.shooter, CustomAttributes.BURST_SPEED.get());
+        double typeMult = 1.0;
+        if (gunType != null) {
+            typeMult = tacz_attributes$getAttributeValue(this.shooter, gunType.getBurstSpeedAttribute().get());
+        }
+        double combined = globalMult * typeMult;
+        if (combined == 1.0) return interval;
+
+        long modified = Math.max(1L, (long) (interval / combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] バースト間隔倍率適用: {}ms -> {}ms (全体: {}, 銃種[{}]: {})",
+                    interval, modified, globalMult,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeMult);
+        }
+
+        return modified;
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/EntityKineticBulletMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/EntityKineticBulletMixin.java
@@ -1,0 +1,140 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.entity.EntityKineticBullet;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * EntityKineticBullet に対するMixin。
+ * <p>
+ * - ノックバック倍率: onHitEntity() 内の KnockBackModifier.setKnockBackStrength() の引数を変更
+ * - 貫通数倍率: コンストラクタ末尾で pierce フィールドを変更
+ */
+@Mixin(EntityKineticBullet.class)
+public abstract class EntityKineticBulletMixin extends Projectile {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    private int pierce;
+
+    @Shadow(remap = false)
+    private ResourceLocation gunId;
+
+    protected EntityKineticBulletMixin(EntityType<? extends Projectile> type, Level level) {
+        super(type, level);
+    }
+
+    /**
+     * onHitEntity() 内の KnockBackModifier.setKnockBackStrength(double) の引数を変更し、
+     * ノックバック基本値を加算した後、ノックバック倍率を適用する。
+     * <p>
+     * 計算式: 最終knockback = (元knockback + knockback_base + 銃種別knockback_base) × knockback_multiplier × 銃種別knockback_multiplier
+     * TaCZの銃はデフォルトknockback=0のため、基本値を加算しないと倍率が効かない。
+     */
+    @ModifyArg(
+            method = "onHitEntity",
+            at = @At(value = "INVOKE", target = "Lcom/tacz/guns/api/entity/KnockBackModifier;setKnockBackStrength(D)V"),
+            remap = false
+    )
+    private double tacz_attributes$modifyKnockback(double knockback) {
+        Entity owner = this.getOwner();
+        if (!(owner instanceof LivingEntity shooter)) return knockback;
+
+        GunType gunType = GunTypeResolver.resolve(this.gunId);
+
+        // 基本値を加算（デフォルト0.0 = 追加なし）
+        double globalBase = tacz_attributes$getKnockbackBaseValue(shooter, CustomAttributes.KNOCKBACK_BASE.get());
+        double typeBase = 0.0;
+        if (gunType != null) {
+            typeBase = tacz_attributes$getKnockbackBaseValue(shooter, gunType.getKnockbackBaseAttribute().get());
+        }
+        double withBase = knockback + globalBase + typeBase;
+
+        // 倍率を適用
+        double globalMult = tacz_attributes$getAttributeValue(shooter, CustomAttributes.KNOCKBACK_MULTIPLIER.get());
+        double typeMult = 1.0;
+        if (gunType != null) {
+            typeMult = tacz_attributes$getAttributeValue(shooter, gunType.getKnockbackMultiplierAttribute().get());
+        }
+        double combinedMult = globalMult * typeMult;
+
+        double result = withBase * combinedMult;
+
+        if (result == knockback) return knockback;
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] ノックバック適用: {} -> {} (基本値追加: +{}+{}, 倍率: {}×{}, 銃種[{}])",
+                    knockback, result, globalBase, typeBase, globalMult, typeMult,
+                    gunType != null ? gunType.getTypeId() : "unknown");
+        }
+
+        return result;
+    }
+
+    /**
+     * コンストラクタ末尾で pierce フィールドを変更し、
+     * 貫通数属性に基づいた倍率を適用する。
+     */
+    @Inject(
+            method = "<init>(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/resources/ResourceLocation;ZLcom/tacz/guns/resource/pojo/data/gun/GunData;Lcom/tacz/guns/resource/pojo/data/gun/BulletData;)V",
+            at = @At("TAIL"),
+            remap = false
+    )
+    private void tacz_attributes$modifyPierce(CallbackInfo ci) {
+        Entity owner = this.getOwner();
+        if (!(owner instanceof LivingEntity shooter)) return;
+
+        GunType gunType = GunTypeResolver.resolve(this.gunId);
+        double globalPierce = tacz_attributes$getAttributeValue(shooter, CustomAttributes.PIERCE_MULTIPLIER.get());
+        double typePierce = 1.0;
+        if (gunType != null) {
+            typePierce = tacz_attributes$getAttributeValue(shooter, gunType.getPierceMultiplierAttribute().get());
+        }
+        double combined = globalPierce * typePierce;
+        if (combined == 1.0) return;
+
+        int oldPierce = this.pierce;
+        this.pierce = Math.max(1, (int) (this.pierce * combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] 貫通数倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
+                    oldPierce, this.pierce, globalPierce,
+                    gunType != null ? gunType.getTypeId() : "unknown", typePierce);
+        }
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+
+    @Unique
+    private static double tacz_attributes$getKnockbackBaseValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 0.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/GunItemRendererWrapperMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/GunItemRendererWrapperMixin.java
@@ -1,0 +1,79 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.client.renderer.item.GunItemRendererWrapper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * GunItemRendererWrapper に対するクライアント側Mixin。
+ * getPutAwayTime() の戻り値をスケーリングし、
+ * しまいアニメーションの速度を draw_speed 属性に基づいて変更する。
+ * <p>
+ * この値は LocalPlayerDraw.draw() → getDrawTime() → renderer.getPutAwayTime() で使用され、
+ * doPutAway（アニメーション）と doDraw（音声タイミング）の両方に影響する。
+ */
+@Mixin(GunItemRendererWrapper.class)
+public class GunItemRendererWrapperMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * getPutAwayTime() の戻り値をdraw_speed属性でスケーリングする。
+     * 戻り値はミリ秒単位。
+     */
+    @Inject(method = "getPutAwayTime", at = @At("RETURN"), remap = false, cancellable = true)
+    private void tacz_attributes$scalePutAwayTime(ItemStack stack, CallbackInfoReturnable<Long> cir) {
+        long time = cir.getReturnValue();
+        if (time <= 0) return;
+
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return;
+
+        double speed = tacz_attributes$getDrawSpeedModifier(player);
+        if (speed == 1.0) return;
+
+        long scaled = Math.max(1L, (long) (time / speed));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] クライアント側PutAway時間スケーリング: {}ms -> {}ms (速度: {})",
+                    time, scaled, speed);
+        }
+
+        cir.setReturnValue(scaled);
+    }
+
+    @Unique
+    private static double tacz_attributes$getDrawSpeedModifier(LocalPlayer player) {
+        double globalSpeed = tacz_attributes$getAttributeValue(player, CustomAttributes.DRAW_SPEED.get());
+
+        // 銃種は切り替え先の武器（メインハンド）で判定
+        GunType gunType = GunTypeResolver.resolveFromItem(player.getMainHandItem());
+        double typeSpeed = 1.0;
+        if (gunType != null) {
+            typeSpeed = tacz_attributes$getAttributeValue(player, gunType.getDrawSpeedAttribute().get());
+        }
+
+        return globalSpeed * typeSpeed;
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LocalPlayer player, Attribute attribute) {
+        if (player.getAttributes().hasAttribute(attribute)) {
+            return player.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityAimMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityAimMixin.java
@@ -1,0 +1,75 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.entity.shooter.LivingEntityAim;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * LivingEntityAim.tickAimingProgress() 内の Math.max(0, aimTime) を @Redirect し、
+ * ADS移行速度属性に基づいた倍率を aimTime に適用するMixin。
+ * <p>
+ * 計算式: 最終aimTime = Math.max(0, aimTime) / (全体ADS速度 × 銃種別ADS速度)
+ * ADS速度 2.0 → aimTime 半分 → 2倍速でADS移行
+ */
+@Mixin(LivingEntityAim.class)
+public class LivingEntityAimMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    @Final
+    private LivingEntity shooter;
+
+    /**
+     * tickAimingProgress() 内の最初の Math.max(float, float) 呼び出しをリダイレクトし、
+     * ADS速度属性でaimTimeを調整する。
+     */
+    @Redirect(
+            method = "tickAimingProgress",
+            at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(FF)F", ordinal = 0),
+            remap = false
+    )
+    private float tacz_attributes$modifyAimTime(float a, float b) {
+        float aimTime = Math.max(a, b);
+        if (aimTime <= 0) return aimTime;
+
+        double globalAdsSpeed = tacz_attributes$getAttributeValue(this.shooter, CustomAttributes.ADS_SPEED.get());
+        GunType gunType = GunTypeResolver.resolveFromItem(this.shooter.getMainHandItem());
+        double typeAdsSpeed = 1.0;
+        if (gunType != null) {
+            typeAdsSpeed = tacz_attributes$getAttributeValue(this.shooter, gunType.getAdsSpeedAttribute().get());
+        }
+        double combined = globalAdsSpeed * typeAdsSpeed;
+        if (combined == 1.0) return aimTime;
+
+        float modified = (float) (aimTime / combined);
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] ADS速度倍率適用: aimTime {} -> {} (全体: {}, 銃種[{}]: {})",
+                    aimTime, modified, globalAdsSpeed,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeAdsSpeed);
+        }
+
+        return Math.max(0, modified);
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityDrawGunMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LivingEntityDrawGunMixin.java
@@ -1,0 +1,132 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.entity.shooter.LivingEntityDrawGun;
+import com.tacz.guns.entity.shooter.ShooterDataHolder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Supplier;
+
+/**
+ * LivingEntityDrawGun に対するMixin。
+ * 武器の取り出し・しまい速度属性に基づいて、draw/holsterクールダウンを変更する。
+ * <p>
+ * 実装方針:
+ * 1. draw() の TAIL で drawTimestamp の未来オフセット（holster時間）をスケーリング
+ * 2. getDrawCoolDown() の RETURN で draw時間分のデルタを減算
+ * <p>
+ * 計算式:
+ * - holster時間 = 元holster時間 / (全体draw_speed × 銃種別draw_speed)
+ * - draw時間 = 元draw時間 / (全体draw_speed × 銃種別draw_speed)
+ */
+@Mixin(LivingEntityDrawGun.class)
+public class LivingEntityDrawGunMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    private LivingEntity shooter;
+
+    @Shadow(remap = false)
+    private ShooterDataHolder data;
+
+    /**
+     * draw() の末尾で drawTimestamp の未来オフセットをスケーリングする。
+     * drawTimestamp = now + holsterTimeMs に設定されているため、
+     * 未来オフセット（holster時間）を draw_speed で除算して短縮する。
+     */
+    @Inject(method = "draw", at = @At("TAIL"), remap = false)
+    private void tacz_attributes$scaleDrawTimestamp(Supplier<ItemStack> gunItemSupplier, CallbackInfo ci) {
+        if (this.shooter == null) return;
+
+        double speed = tacz_attributes$getDrawSpeedModifier();
+        if (speed == 1.0) return;
+
+        long now = System.currentTimeMillis();
+        long futureOffset = this.data.drawTimestamp - now;
+        if (futureOffset > 0) {
+            long scaledOffset = (long) (futureOffset / speed);
+            this.data.drawTimestamp = now + scaledOffset;
+
+            if (!FMLEnvironment.production) {
+                LOGGER.info("[TaCZ Attributes] Holster時間スケーリング: {}ms -> {}ms (速度: {})",
+                        futureOffset, scaledOffset, speed);
+            }
+        }
+    }
+
+    /**
+     * getDrawCoolDown() の戻り値からdraw時間分のデルタを減算する。
+     * <p>
+     * coolDown = drawTimeMs - (now - drawTimestamp) - 5
+     * holster時間は既にdrawTimestampに反映済み。
+     * draw時間を短縮するため、drawTimeMs × (1 - 1/speed) を減算する。
+     */
+    @Inject(method = "getDrawCoolDown", at = @At("RETURN"), remap = false, cancellable = true)
+    private void tacz_attributes$scaleDrawCoolDown(CallbackInfoReturnable<Long> cir) {
+        long coolDown = cir.getReturnValue();
+        if (coolDown <= 0) return;
+        if (this.shooter == null || this.data.currentGunItem == null) return;
+
+        double speed = tacz_attributes$getDrawSpeedModifier();
+        if (speed == 1.0) return;
+
+        ItemStack gunItem = this.data.currentGunItem.get();
+        if (!(gunItem.getItem() instanceof IGun iGun)) return;
+
+        ResourceLocation gunId = iGun.getGunId(gunItem);
+        TimelessAPI.getCommonGunIndex(gunId).ifPresent(index -> {
+            long drawMs = (long) (index.getGunData().getDrawTime() * 1000);
+            long delta = (long) (drawMs * (1.0 - 1.0 / speed));
+            long adjusted = Math.max(0L, coolDown - delta);
+
+            if (!FMLEnvironment.production && adjusted != coolDown) {
+                LOGGER.info("[TaCZ Attributes] Draw時間スケーリング: coolDown {}ms -> {}ms (drawMs: {}, delta: {}, 速度: {})",
+                        coolDown, adjusted, drawMs, delta, speed);
+            }
+
+            cir.setReturnValue(adjusted);
+        });
+    }
+
+    @Unique
+    private double tacz_attributes$getDrawSpeedModifier() {
+        if (this.shooter == null) return 1.0;
+
+        double globalSpeed = tacz_attributes$getAttributeValue(this.shooter, CustomAttributes.DRAW_SPEED.get());
+
+        // 銃種は切り替え先の武器（メインハンド）で判定
+        GunType gunType = GunTypeResolver.resolveFromItem(this.shooter.getMainHandItem());
+        double typeSpeed = 1.0;
+        if (gunType != null) {
+            typeSpeed = tacz_attributes$getAttributeValue(this.shooter, gunType.getDrawSpeedAttribute().get());
+        }
+
+        return globalSpeed * typeSpeed;
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LocalPlayerAimMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LocalPlayerAimMixin.java
@@ -1,0 +1,76 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.client.gameplay.LocalPlayerAim;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * LocalPlayerAim.getAlphaProgress() 内の Math.max(0, aimTime) を @Redirect し、
+ * ADS移行速度属性に基づいた倍率を aimTime に適用するクライアント側Mixin。
+ * <p>
+ * サーバー側の LivingEntityAimMixin と同じ倍率を適用し、
+ * ADSアニメーションの視覚的速度とゲームロジックを一致させる。
+ */
+@Mixin(LocalPlayerAim.class)
+public class LocalPlayerAimMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    @Final
+    private LocalPlayer player;
+
+    /**
+     * getAlphaProgress() 内の Math.max(float, float) 呼び出しをリダイレクトし、
+     * ADS速度属性でaimTimeを調整する（クライアント側アニメーション用）。
+     */
+    @Redirect(
+            method = "getAlphaProgress",
+            at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(FF)F", ordinal = 0),
+            remap = false
+    )
+    private float tacz_attributes$modifyClientAimTime(float a, float b) {
+        float aimTime = Math.max(a, b);
+        if (aimTime <= 0) return aimTime;
+
+        double globalAdsSpeed = tacz_attributes$getAttributeValue(this.player, CustomAttributes.ADS_SPEED.get());
+        GunType gunType = GunTypeResolver.resolveFromItem(this.player.getMainHandItem());
+        double typeAdsSpeed = 1.0;
+        if (gunType != null) {
+            typeAdsSpeed = tacz_attributes$getAttributeValue(this.player, gunType.getAdsSpeedAttribute().get());
+        }
+        double combined = globalAdsSpeed * typeAdsSpeed;
+        if (combined == 1.0) return aimTime;
+
+        float modified = (float) (aimTime / combined);
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] クライアントADS速度倍率適用: aimTime {} -> {} (全体: {}, 銃種[{}]: {})",
+                    aimTime, modified, globalAdsSpeed,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeAdsSpeed);
+        }
+
+        return Math.max(0, modified);
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/LocalPlayerShootMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/LocalPlayerShootMixin.java
@@ -1,0 +1,128 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.api.item.gun.FireMode;
+import com.tacz.guns.client.gameplay.LocalPlayerShoot;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * LocalPlayerShoot.doShoot() に対するクライアント側Mixin。
+ * <p>
+ * 1. バースト弾数倍率のクライアント同期（反動・音声の修正）:
+ *    cycles (int ordinal 1) を変更して、追加バーストショットの反動・音声を再生させる。
+ * <p>
+ * 2. バースト速度倍率:
+ *    burstShootInterval (long ordinal 0) を変更して、バースト内の射撃間隔を調整する。
+ */
+@Mixin(LocalPlayerShoot.class)
+public class LocalPlayerShootMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    private LocalPlayer player;
+
+    /**
+     * doShoot() 内の cycles (int ordinal 1) を変更し、
+     * バースト弾数倍率をクライアント側に反映する。
+     * <p>
+     * これにより追加されたバーストショットの反動アニメーションと音声が再生される。
+     */
+    @ModifyVariable(
+            method = "doShoot",
+            at = @At("STORE"),
+            ordinal = 1,
+            remap = false
+    )
+    private int tacz_attributes$modifyClientCycles(int cycles) {
+        if (this.player == null || cycles <= 1) return cycles;
+
+        ItemStack stack = this.player.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(stack);
+        if (iGun == null) return cycles;
+        FireMode mode = iGun.getFireMode(stack);
+        if (mode != FireMode.BURST) return cycles;
+
+        GunType gunType = GunTypeResolver.resolveFromItem(stack);
+        double globalMult = tacz_attributes$getAttrValue(CustomAttributes.BURST_BULLET_AMOUNT.get());
+        double typeMult = 1.0;
+        if (gunType != null) {
+            typeMult = tacz_attributes$getAttrValue(gunType.getBurstBulletAmountAttribute().get());
+        }
+        double combined = globalMult * typeMult;
+        if (combined == 1.0) return cycles;
+
+        int modified = Math.max(1, (int) (cycles * combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] クライアント側バースト弾数倍率適用: {} -> {} (全体: {}, 銃種[{}]: {})",
+                    cycles, modified, globalMult,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeMult);
+        }
+
+        return modified;
+    }
+
+    /**
+     * doShoot() 内の period (long ordinal 1) を変更し、
+     * バースト間隔速度倍率をクライアント側に反映する。
+     * <p>
+     * LVT上の long 変数: ordinal 0 = delay（メソッドパラメータ）、ordinal 1 = period（ローカル変数）
+     * burst_speed 2.0 → 間隔半分 → より速いバースト（音声・反動のタイミングに反映）
+     */
+    @ModifyVariable(
+            method = "doShoot",
+            at = @At("STORE"),
+            ordinal = 1,
+            remap = false
+    )
+    private long tacz_attributes$modifyClientBurstInterval(long interval) {
+        if (this.player == null || interval <= 1) return interval;
+
+        ItemStack stack = this.player.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(stack);
+        if (iGun == null) return interval;
+        FireMode mode = iGun.getFireMode(stack);
+        if (mode != FireMode.BURST) return interval;
+
+        GunType gunType = GunTypeResolver.resolveFromItem(stack);
+        double globalMult = tacz_attributes$getAttrValue(CustomAttributes.BURST_SPEED.get());
+        double typeMult = 1.0;
+        if (gunType != null) {
+            typeMult = tacz_attributes$getAttrValue(gunType.getBurstSpeedAttribute().get());
+        }
+        double combined = globalMult * typeMult;
+        if (combined == 1.0) return interval;
+
+        long modified = Math.max(1L, (long) (interval / combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] クライアント側バースト間隔倍率適用: {}ms -> {}ms (全体: {}, 銃種[{}]: {})",
+                    interval, modified, globalMult,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeMult);
+        }
+
+        return modified;
+    }
+
+    @Unique
+    private double tacz_attributes$getAttrValue(Attribute attribute) {
+        if (this.player != null && this.player.getAttributes().hasAttribute(attribute)) {
+            return this.player.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/RecoilMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/RecoilMixin.java
@@ -1,0 +1,168 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.entity.IGunOperator;
+import com.tacz.guns.client.event.CameraSetupEvent;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+/**
+ * 反動属性をカメラリコイルに適用するMixin。
+ * <p>
+ * CameraSetupEvent.initialCameraRecoil() 内の genPitchSplineFunction / genYawSplineFunction
+ * 呼び出しの引数を @ModifyArg で変更し、反動属性の倍率をmodifierに乗算する。
+ * <p>
+ * 適用される反動属性:
+ * - 全般反動倍率（全体 × 銃種別）
+ * - 縦/横反動倍率（全体 × 銃種別）
+ * - ADS/腰撃ち反動倍率（全体 × 銃種別）
+ * - ADS/腰撃ち縦/横反動倍率（全体 × 銃種別）
+ * <p>
+ * 計算式（Pitch）: modifier × 全般反動 × 縦反動 × ADS/腰撃ち反動 × ADS/腰撃ち縦反動
+ *                  × 銃種全般反動 × 銃種縦反動 × 銃種ADS/腰撃ち反動 × 銃種ADS/腰撃ち縦反動
+ * 計算式（Yaw）:   modifier × 全般反動 × 横反動 × ADS/腰撃ち反動 × ADS/腰撃ち横反動
+ *                  × 銃種全般反動 × 銃種横反動 × 銃種ADS/腰撃ち反動 × 銃種ADS/腰撃ち横反動
+ */
+@Mixin(CameraSetupEvent.class)
+public class RecoilMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * initialCameraRecoil() 内の genPitchSplineFunction(float) の引数を変更し、
+     * 縦反動属性に基づいた倍率をmodifierに適用する。
+     */
+    @ModifyArg(
+            method = "initialCameraRecoil",
+            at = @At(value = "INVOKE", target = "Lcom/tacz/guns/resource/pojo/data/gun/GunRecoil;genPitchSplineFunction(F)Lorg/apache/commons/math3/analysis/polynomials/PolynomialSplineFunction;"),
+            remap = false
+    )
+    private static float tacz_attributes$modifyPitchRecoilArg(float modifier) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return modifier;
+
+        boolean isAds = IGunOperator.fromLivingEntity(player).getSynIsAiming();
+        GunType gunType = GunTypeResolver.resolveFromItem(player.getMainHandItem());
+
+        // 全般反動 × 縦反動
+        double globalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.RECOIL.get());
+        double verticalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.VERTICAL_RECOIL.get());
+
+        // ADS/腰撃ち反動 × ADS/腰撃ち縦反動
+        double adsHipRecoil;
+        double adsHipVerticalRecoil;
+        if (isAds) {
+            adsHipRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.ADS_RECOIL.get());
+            adsHipVerticalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.ADS_VERTICAL_RECOIL.get());
+        } else {
+            adsHipRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.HIP_FIRE_RECOIL.get());
+            adsHipVerticalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.HIP_FIRE_VERTICAL_RECOIL.get());
+        }
+
+        // 銃種別
+        double typeRecoil = 1.0, typeVertical = 1.0, typeAdsHip = 1.0, typeAdsHipVertical = 1.0;
+        if (gunType != null) {
+            typeRecoil = tacz_attributes$getAttributeValue(player, gunType.getRecoilAttribute().get());
+            typeVertical = tacz_attributes$getAttributeValue(player, gunType.getVerticalRecoilAttribute().get());
+            if (isAds) {
+                typeAdsHip = tacz_attributes$getAttributeValue(player, gunType.getAdsRecoilAttribute().get());
+                typeAdsHipVertical = tacz_attributes$getAttributeValue(player, gunType.getAdsVerticalRecoilAttribute().get());
+            } else {
+                typeAdsHip = tacz_attributes$getAttributeValue(player, gunType.getHipFireRecoilAttribute().get());
+                typeAdsHipVertical = tacz_attributes$getAttributeValue(player, gunType.getHipFireVerticalRecoilAttribute().get());
+            }
+        }
+
+        double combinedModifier = globalRecoil * verticalRecoil * adsHipRecoil * adsHipVerticalRecoil
+                * typeRecoil * typeVertical * typeAdsHip * typeAdsHipVertical;
+        if (combinedModifier == 1.0) return modifier;
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] 縦反動倍率適用: modifier {} -> {} (全般: {}, 縦: {}, {}: {}×{}, 銃種[{}]: {}×{}×{}×{})",
+                    modifier, modifier * (float) combinedModifier, globalRecoil, verticalRecoil,
+                    isAds ? "ADS" : "腰撃ち", adsHipRecoil, adsHipVerticalRecoil,
+                    gunType != null ? gunType.getTypeId() : "unknown",
+                    typeRecoil, typeVertical, typeAdsHip, typeAdsHipVertical);
+        }
+
+        return modifier * (float) combinedModifier;
+    }
+
+    /**
+     * initialCameraRecoil() 内の genYawSplineFunction(float) の引数を変更し、
+     * 横反動属性に基づいた倍率をmodifierに適用する。
+     */
+    @ModifyArg(
+            method = "initialCameraRecoil",
+            at = @At(value = "INVOKE", target = "Lcom/tacz/guns/resource/pojo/data/gun/GunRecoil;genYawSplineFunction(F)Lorg/apache/commons/math3/analysis/polynomials/PolynomialSplineFunction;"),
+            remap = false
+    )
+    private static float tacz_attributes$modifyYawRecoilArg(float modifier) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return modifier;
+
+        boolean isAds = IGunOperator.fromLivingEntity(player).getSynIsAiming();
+        GunType gunType = GunTypeResolver.resolveFromItem(player.getMainHandItem());
+
+        // 全般反動 × 横反動
+        double globalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.RECOIL.get());
+        double horizontalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.HORIZONTAL_RECOIL.get());
+
+        // ADS/腰撃ち反動 × ADS/腰撃ち横反動
+        double adsHipRecoil;
+        double adsHipHorizontalRecoil;
+        if (isAds) {
+            adsHipRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.ADS_RECOIL.get());
+            adsHipHorizontalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.ADS_HORIZONTAL_RECOIL.get());
+        } else {
+            adsHipRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.HIP_FIRE_RECOIL.get());
+            adsHipHorizontalRecoil = tacz_attributes$getAttributeValue(player, CustomAttributes.HIP_FIRE_HORIZONTAL_RECOIL.get());
+        }
+
+        // 銃種別
+        double typeRecoil = 1.0, typeHorizontal = 1.0, typeAdsHip = 1.0, typeAdsHipHorizontal = 1.0;
+        if (gunType != null) {
+            typeRecoil = tacz_attributes$getAttributeValue(player, gunType.getRecoilAttribute().get());
+            typeHorizontal = tacz_attributes$getAttributeValue(player, gunType.getHorizontalRecoilAttribute().get());
+            if (isAds) {
+                typeAdsHip = tacz_attributes$getAttributeValue(player, gunType.getAdsRecoilAttribute().get());
+                typeAdsHipHorizontal = tacz_attributes$getAttributeValue(player, gunType.getAdsHorizontalRecoilAttribute().get());
+            } else {
+                typeAdsHip = tacz_attributes$getAttributeValue(player, gunType.getHipFireRecoilAttribute().get());
+                typeAdsHipHorizontal = tacz_attributes$getAttributeValue(player, gunType.getHipFireHorizontalRecoilAttribute().get());
+            }
+        }
+
+        double combinedModifier = globalRecoil * horizontalRecoil * adsHipRecoil * adsHipHorizontalRecoil
+                * typeRecoil * typeHorizontal * typeAdsHip * typeAdsHipHorizontal;
+        if (combinedModifier == 1.0) return modifier;
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] 横反動倍率適用: modifier {} -> {} (全般: {}, 横: {}, {}: {}×{}, 銃種[{}]: {}×{}×{}×{})",
+                    modifier, modifier * (float) combinedModifier, globalRecoil, horizontalRecoil,
+                    isAds ? "ADS" : "腰撃ち", adsHipRecoil, adsHipHorizontalRecoil,
+                    gunType != null ? gunType.getTypeId() : "unknown",
+                    typeRecoil, typeHorizontal, typeAdsHip, typeAdsHipHorizontal);
+        }
+
+        return modifier * (float) combinedModifier;
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LocalPlayer player, Attribute attribute) {
+        if (player.getAttributes().hasAttribute(attribute)) {
+            return player.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/ShootInaccuracyMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/ShootInaccuracyMixin.java
@@ -1,0 +1,104 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.FireModeHelper;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.entity.IGunOperator;
+import com.tacz.guns.api.item.gun.FireMode;
+import com.tacz.guns.item.ModernKineticGunScriptAPI;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * 精度属性を射撃の散布度に適用するMixin。
+ * <p>
+ * ModernKineticGunScriptAPI.shootOnce() 内の Math.max(FF)F 呼び出しを @Redirect し、
+ * 計算された inaccuracy 値に精度属性の倍率を適用する。
+ * <p>
+ * 適用される精度属性:
+ * - 腰撃ち/ADS精度（全体 × 銃種別）
+ * - 射撃モード別精度（全体 × 銃種別）
+ * <p>
+ * 計算式: final_inaccuracy = base_inaccuracy / (全体精度 × 銃種別精度 × モード全体精度 × モード銃種別精度)
+ */
+@Mixin(ModernKineticGunScriptAPI.class)
+public class ShootInaccuracyMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Shadow(remap = false)
+    private LivingEntity shooter;
+
+    @Shadow(remap = false)
+    private ItemStack itemStack;
+
+    /**
+     * shootOnce() 内の Math.max(0, inaccuracy) を差し替え、
+     * 精度属性に基づいた倍率を適用する。
+     */
+    @Redirect(
+            method = "shootOnce",
+            at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(FF)F"),
+            remap = false
+    )
+    private float tacz_attributes$modifyInaccuracy(float a, float b) {
+        float originalInaccuracy = Math.max(a, b);
+        if (shooter == null) return originalInaccuracy;
+
+        // ADS / 腰撃ち精度
+        boolean isAds = IGunOperator.fromLivingEntity(shooter).getSynIsAiming();
+        GunType gunType = GunTypeResolver.resolveFromItem(itemStack);
+
+        double adsHipGlobal;
+        double adsHipType = 1.0;
+        if (isAds) {
+            adsHipGlobal = tacz_attributes$getAttributeValue(CustomAttributes.ADS_ACCURACY.get());
+            if (gunType != null) {
+                adsHipType = tacz_attributes$getAttributeValue(gunType.getAdsAccuracyAttribute().get());
+            }
+        } else {
+            adsHipGlobal = tacz_attributes$getAttributeValue(CustomAttributes.HIP_FIRE_ACCURACY.get());
+            if (gunType != null) {
+                adsHipType = tacz_attributes$getAttributeValue(gunType.getHipFireAccuracyAttribute().get());
+            }
+        }
+
+        // 射撃モード別精度
+        FireMode fireMode = FireModeHelper.getFireMode(itemStack);
+        double fireModeGlobal = FireModeHelper.getAttributeValue(shooter, FireModeHelper.getGlobalAccuracyAttribute(fireMode));
+        double fireModeType = FireModeHelper.getAttributeValue(shooter, FireModeHelper.getTypeAccuracyAttribute(gunType, fireMode));
+
+        double combinedAccuracy = adsHipGlobal * adsHipType * fireModeGlobal * fireModeType;
+        if (combinedAccuracy == 1.0) return originalInaccuracy;
+
+        float modifiedInaccuracy = (float) (originalInaccuracy / combinedAccuracy);
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] 精度属性適用: inaccuracy {} -> {} (ADS: {}, 腰撃ち/ADS精度: {}×{}, モード[{}]精度: {}×{})",
+                    originalInaccuracy, modifiedInaccuracy, isAds,
+                    adsHipGlobal, adsHipType,
+                    fireMode != null ? fireMode.name() : "unknown",
+                    fireModeGlobal, fireModeType);
+        }
+
+        return modifiedInaccuracy;
+    }
+
+    @Unique
+    private double tacz_attributes$getAttributeValue(Attribute attribute) {
+        if (shooter.getAttributes().hasAttribute(attribute)) {
+            return shooter.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/mixin/ShootIntervalMixin.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/mixin/ShootIntervalMixin.java
@@ -1,0 +1,70 @@
+package com.github.leopoko.tacz_attributes.mixin;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.github.leopoko.tacz_attributes.util.GunTypeResolver;
+import com.tacz.guns.api.item.gun.FireMode;
+import com.tacz.guns.resource.pojo.data.gun.GunData;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * GunData.getShootInterval() の戻り値を変更し、
+ * RPM倍率属性に基づいた発射レートの変更を適用するMixin。
+ * <p>
+ * 計算式: 最終インターバル = 元インターバル / (全体RPM倍率 × 銃種別RPM倍率)
+ * RPM倍率 2.0 → インターバル半分 → 2倍速射
+ */
+@Mixin(GunData.class)
+public class ShootIntervalMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Inject(
+            method = "getShootInterval",
+            at = @At("RETURN"),
+            remap = false,
+            cancellable = true
+    )
+    private void tacz_attributes$modifyShootInterval(LivingEntity shooter, FireMode fireMode,
+                                                      ItemStack gunStack, CallbackInfoReturnable<Long> cir) {
+        if (shooter == null) return;
+
+        GunType gunType = GunTypeResolver.resolveFromItem(gunStack);
+        double globalRpm = tacz_attributes$getAttributeValue(shooter, CustomAttributes.RPM_MULTIPLIER.get());
+        double typeRpm = 1.0;
+        if (gunType != null) {
+            typeRpm = tacz_attributes$getAttributeValue(shooter, gunType.getRpmMultiplierAttribute().get());
+        }
+        double combined = globalRpm * typeRpm;
+        if (combined == 1.0) return;
+
+        long original = cir.getReturnValue();
+        long modified = Math.max(1L, (long) (original / combined));
+
+        if (!FMLEnvironment.production) {
+            LOGGER.info("[TaCZ Attributes] RPM倍率適用: interval {} -> {} ms (全体: {}, 銃種[{}]: {})",
+                    original, modified, globalRpm,
+                    gunType != null ? gunType.getTypeId() : "unknown", typeRpm);
+        }
+
+        cir.setReturnValue(modified);
+    }
+
+    @Unique
+    private static double tacz_attributes$getAttributeValue(LivingEntity entity, Attribute attribute) {
+        if (entity.getAttributes().hasAttribute(attribute)) {
+            return entity.getAttributeValue(attribute);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/java/com/github/leopoko/tacz_attributes/util/FireModeHelper.java
+++ b/src/main/java/com/github/leopoko/tacz_attributes/util/FireModeHelper.java
@@ -1,0 +1,100 @@
+package com.github.leopoko.tacz_attributes.util;
+
+import com.github.leopoko.tacz_attributes.attribute.CustomAttributes;
+import com.github.leopoko.tacz_attributes.attribute.GunType;
+import com.tacz.guns.api.item.IGun;
+import com.tacz.guns.api.item.gun.FireMode;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.RegistryObject;
+
+import javax.annotation.Nullable;
+
+/**
+ * FireMode（射撃モード）に基づく属性値の解決ユーティリティ。
+ */
+public final class FireModeHelper {
+
+    private FireModeHelper() {}
+
+    /**
+     * ItemStack から現在の FireMode を取得する。
+     */
+    @Nullable
+    public static FireMode getFireMode(@Nullable ItemStack stack) {
+        if (stack == null || stack.isEmpty()) return null;
+        IGun iGun = IGun.getIGunOrNull(stack);
+        if (iGun == null) return null;
+        FireMode mode = iGun.getFireMode(stack);
+        return mode == FireMode.UNKNOWN ? null : mode;
+    }
+
+    /**
+     * 射撃モードに対応する全体ダメージ属性を取得する。
+     */
+    @Nullable
+    public static RegistryObject<Attribute> getGlobalDamageAttribute(@Nullable FireMode mode) {
+        if (mode == null) return null;
+        return switch (mode) {
+            case AUTO -> CustomAttributes.AUTO_DAMAGE;
+            case SEMI -> CustomAttributes.SEMI_DAMAGE;
+            case BURST -> CustomAttributes.BURST_DAMAGE;
+            default -> null;
+        };
+    }
+
+    /**
+     * 射撃モードに対応する全体精度属性を取得する。
+     */
+    @Nullable
+    public static RegistryObject<Attribute> getGlobalAccuracyAttribute(@Nullable FireMode mode) {
+        if (mode == null) return null;
+        return switch (mode) {
+            case AUTO -> CustomAttributes.AUTO_ACCURACY;
+            case SEMI -> CustomAttributes.SEMI_ACCURACY;
+            case BURST -> CustomAttributes.BURST_ACCURACY;
+            default -> null;
+        };
+    }
+
+    /**
+     * 射撃モードに対応する銃種別ダメージ属性を取得する。
+     */
+    @Nullable
+    public static RegistryObject<Attribute> getTypeDamageAttribute(@Nullable GunType gunType, @Nullable FireMode mode) {
+        if (gunType == null || mode == null) return null;
+        return switch (mode) {
+            case AUTO -> gunType.getAutoDamageAttribute();
+            case SEMI -> gunType.getSemiDamageAttribute();
+            case BURST -> gunType.getBurstDamageAttribute();
+            default -> null;
+        };
+    }
+
+    /**
+     * 射撃モードに対応する銃種別精度属性を取得する。
+     */
+    @Nullable
+    public static RegistryObject<Attribute> getTypeAccuracyAttribute(@Nullable GunType gunType, @Nullable FireMode mode) {
+        if (gunType == null || mode == null) return null;
+        return switch (mode) {
+            case AUTO -> gunType.getAutoAccuracyAttribute();
+            case SEMI -> gunType.getSemiAccuracyAttribute();
+            case BURST -> gunType.getBurstAccuracyAttribute();
+            default -> null;
+        };
+    }
+
+    /**
+     * エンティティから属性値を取得する。属性が未登録の場合は 1.0 を返す。
+     */
+    public static double getAttributeValue(LivingEntity entity, @Nullable RegistryObject<Attribute> attribute) {
+        if (attribute == null) return 1.0;
+        Attribute attr = attribute.get();
+        if (entity.getAttributes().hasAttribute(attr)) {
+            return entity.getAttributeValue(attr);
+        }
+        return 1.0;
+    }
+}

--- a/src/main/resources/tacz_attributes.mixins.json
+++ b/src/main/resources/tacz_attributes.mixins.json
@@ -20,7 +20,8 @@
     "ObjectAnimationRunnerMixin",
     "RecoilMixin",
     "LocalPlayerAimMixin",
-    "GunItemRendererWrapperMixin"
+    "GunItemRendererWrapperMixin",
+    "LocalPlayerShootMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/tacz_attributes.mixins.json
+++ b/src/main/resources/tacz_attributes.mixins.json
@@ -8,10 +8,19 @@
     "LivingEntityReloadMixin",
     "LivingEntityBoltMixin",
     "GunDataMixin",
-    "ModernKineticGunScriptAPIMixin"
+    "ModernKineticGunScriptAPIMixin",
+    "ShootInaccuracyMixin",
+    "EntityKineticBulletMixin",
+    "ShootIntervalMixin",
+    "LivingEntityAimMixin",
+    "BulletAmountMixin",
+    "LivingEntityDrawGunMixin"
   ],
   "client": [
-    "ObjectAnimationRunnerMixin"
+    "ObjectAnimationRunnerMixin",
+    "RecoilMixin",
+    "LocalPlayerAimMixin",
+    "GunItemRendererWrapperMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## 概要

銃の属性システムを大幅に拡張し、23種類の新しいカスタム属性（全銃共通）と、それに対応する銃種別属性を実装しました。これにより、銃のあらゆる挙動をMinecraftの属性システム（AttributeModifier）で細かく制御できるようになります。

## 新規属性一覧

### ダメージ系
- `hip_fire_damage` / `ads_damage` — 腰撃ち・ADSダメージ倍率
- `auto_damage` / `semi_damage` / `burst_damage` — 射撃モード別ダメージ倍率
- `headshot_multiplier` — ヘッドショット倍率

### 精度系
- `hip_fire_accuracy` / `ads_accuracy` — 腰撃ち・ADS精度倍率
- `auto_accuracy` / `semi_accuracy` / `burst_accuracy` — 射撃モード別精度倍率

### 反動系（9属性）
- `recoil` / `vertical_recoil` / `horizontal_recoil` — 全般・縦・横反動倍率
- `ads_recoil` / `ads_vertical_recoil` / `ads_horizontal_recoil` — ADS反動倍率
- `hip_fire_recoil` / `hip_fire_vertical_recoil` / `hip_fire_horizontal_recoil` — 腰撃ち反動倍率

### 速度・メカニクス系
- `gun_movement_speed` — 銃装備時移動速度倍率
- `rpm_multiplier` — 発射レート(RPM)倍率
- `ads_speed` — ADS移行速度倍率
- `draw_speed` — 武器切替速度倍率（取り出し・しまい両方）
- `burst_speed` — バースト内射撃間隔速度倍率

### 弾丸系
- `semi_bullet_amount` / `auto_bullet_amount` / `burst_bullet_amount` — 射撃モード別弾数倍率
- `knockback_multiplier` / `knockback_base` — ノックバック倍率・基本値
- `pierce_multiplier` — 貫通数倍率

すべての属性は銃種別（PISTOL, SNIPER, RIFLE, SHOTGUN, SMG, RPG, MG）にも対応しており、`最終値 = 全体属性 × 銃種別属性` として計算されます。

## 実装内容

### 新規Mixin（10個）
| Mixin | 対象 | 機能 |
|-------|------|------|
| `ShootInaccuracyMixin` | ModernKineticGunScriptAPI | 腰撃ち/ADS/モード別精度の適用 |
| `RecoilMixin` | CameraSetupEvent (Client) | 反動属性の適用（pitch/yaw） |
| `EntityKineticBulletMixin` | EntityKineticBullet | ノックバック・貫通数の適用 |
| `ShootIntervalMixin` | GunData | RPM倍率の適用 |
| `LivingEntityAimMixin` | LivingEntityAim (Server) | ADS速度の適用 |
| `LocalPlayerAimMixin` | LocalPlayerAim (Client) | ADSアニメーション速度の適用 |
| `BulletAmountMixin` | ModernKineticGunScriptAPI (Server) | 弾数・バースト速度の適用 |
| `LocalPlayerShootMixin` | LocalPlayerShoot (Client) | バースト弾数・速度のクライアント同期 |
| `LivingEntityDrawGunMixin` | LivingEntityDrawGun (Server) | 武器切替速度の適用 |
| `GunItemRendererWrapperMixin` | GunItemRendererWrapper (Client) | しまいアニメーション速度の適用 |

### 新規ハンドラ・ユーティリティ
| ファイル | 機能 |
|---------|------|
| `GunMovementSpeedHandler` | 銃装備時移動速度のTickEvent適用 |
| `DrawAnimationSpeedHandler` | Drawアニメーション速度のクライアント側同期 |
| `FireModeHelper` | 射撃モード別属性の解決ユーティリティ |

### 既存ファイルの変更
- `GunDamageModifier` — ADS/腰撃ち・モード別ダメージ倍率とヘッドショット倍率の適用を追加
- `CustomAttributes` — 23個の新規属性定義を追加
- `GunType` — 銃種別に23属性のフィールド・ゲッター・登録を追加
- `EntityAttributeSetup` — 全新規属性のプレイヤーへのバインドを追加

## テスト計画

- [x] `./gradlew build` が成功すること
- [ ] ゲーム内で各属性をコマンドで変更し、効果を確認
- [ ] 銃種別属性が正しく銃種ごとに適用されること
- [ ] サーバー・クライアント間で属性値が正しく同期されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)